### PR TITLE
Restrict print templates

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -147,6 +147,7 @@
 
     create table user_group (
        id uuid not null,
+        name varchar(255),
         primary key (id)
     );
 
@@ -178,6 +179,9 @@
         primary key (id)
     );
 create index cases_case_ref_idx on cases (case_ref);
+
+    alter table if exists users 
+       add constraint users_email_idx unique (email);
 
     alter table if exists action_rule 
        add constraint FK6twtf1ksysh99e4g2ejmoy6c1 

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -1,14 +1,19 @@
 
     create table action_rule (
        id uuid not null,
-        classifiers bytea not null,
+        classifiers bytea,
         has_triggered BOOLEAN DEFAULT false not null,
-        pack_code varchar(255),
-        print_supplier varchar(255),
-        template jsonb,
         trigger_date_time timestamp with time zone,
         type varchar(255),
         collection_exercise_id uuid,
+        print_template_pack_code varchar(255),
+        primary key (id)
+    );
+
+    create table action_rule_survey_print_template (
+       id uuid not null,
+        print_template_pack_code varchar(255),
+        survey_id uuid,
         primary key (id)
     );
 
@@ -72,19 +77,19 @@
         primary key (id)
     );
 
-    create table fulfilment_template (
-       fulfilment_code varchar(255) not null,
-        print_supplier varchar(255),
-        template jsonb,
-        primary key (fulfilment_code)
+    create table fulfilment_survey_print_template (
+       id uuid not null,
+        print_template_pack_code varchar(255),
+        survey_id uuid,
+        primary key (id)
     );
 
     create table fulfilment_to_process (
        id  bigserial not null,
         batch_id uuid,
         batch_quantity int4,
-        fulfilment_code varchar(255),
         caze_id uuid,
+        print_template_pack_code varchar(255),
         primary key (id)
     );
 
@@ -113,6 +118,13 @@
         validation_error_descriptions varchar(255),
         job_id uuid,
         primary key (id)
+    );
+
+    create table print_template (
+       pack_code varchar(255) not null,
+        print_supplier varchar(255),
+        template jsonb,
+        primary key (pack_code)
     );
 
     create table survey (
@@ -153,6 +165,21 @@ create index cases_case_ref_idx on cases (case_ref);
        foreign key (collection_exercise_id) 
        references collection_exercise;
 
+    alter table if exists action_rule 
+       add constraint FK5pwarbhvswl774xodfnxgasvi 
+       foreign key (print_template_pack_code) 
+       references print_template;
+
+    alter table if exists action_rule_survey_print_template 
+       add constraint FK2p5hm28uix0uqs3gl2mdne2a7 
+       foreign key (print_template_pack_code) 
+       references print_template;
+
+    alter table if exists action_rule_survey_print_template 
+       add constraint FKfqpwm5s5wjqfvm7p2vhmw2e59 
+       foreign key (survey_id) 
+       references survey;
+
     alter table if exists cases 
        add constraint FKrl77p02uu7a253tn2ro5mitv5 
        foreign key (collection_exercise_id) 
@@ -183,10 +210,25 @@ create index cases_case_ref_idx on cases (case_ref);
        foreign key (uac_qid_link_id) 
        references uac_qid_link;
 
+    alter table if exists fulfilment_survey_print_template 
+       add constraint FKf1n5yseu1tlkmeasblbsxw9ky 
+       foreign key (print_template_pack_code) 
+       references print_template;
+
+    alter table if exists fulfilment_survey_print_template 
+       add constraint FKkarksqk2he61rw37g8hp0jvjj 
+       foreign key (survey_id) 
+       references survey;
+
     alter table if exists fulfilment_to_process 
        add constraint FK9cu8edtrwirw777f4x1qej03m 
        foreign key (caze_id) 
        references cases;
+
+    alter table if exists fulfilment_to_process 
+       add constraint FK8a3y4pwp485sgxxlr064n7rxc 
+       foreign key (print_template_pack_code) 
+       references print_template;
 
     alter table if exists job 
        add constraint FK6hra36ow5xge19dg3w1m7fd4r 

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -145,20 +145,39 @@
         primary key (id)
     );
 
+    create table user_group (
+       id uuid not null,
+        primary key (id)
+    );
+
+    create table user_group_admin (
+       id uuid not null,
+        group_id uuid,
+        user_id uuid,
+        primary key (id)
+    );
+
+    create table user_group_member (
+       id uuid not null,
+        group_id uuid,
+        user_id uuid,
+        primary key (id)
+    );
+
+    create table user_group_permission (
+       id uuid not null,
+        authorised_activity varchar(255),
+        group_id uuid,
+        survey_id uuid,
+        primary key (id)
+    );
+
     create table users (
        id uuid not null,
         email varchar(255),
         primary key (id)
     );
-
-    create table users_survey (
-       user_id uuid not null,
-        surveys_id uuid not null
-    );
 create index cases_case_ref_idx on cases (case_ref);
-
-    alter table if exists users_survey 
-       add constraint UK_6m5sfm18vispsa7os6vhrt09r unique (surveys_id);
 
     alter table if exists action_rule 
        add constraint FK6twtf1ksysh99e4g2ejmoy6c1 
@@ -245,12 +264,32 @@ create index cases_case_ref_idx on cases (case_ref);
        foreign key (caze_id) 
        references cases;
 
-    alter table if exists users_survey 
-       add constraint FKlru4axdl8yjkpa9srv4xu814s 
-       foreign key (surveys_id) 
-       references survey;
+    alter table if exists user_group_admin 
+       add constraint FKc7secqw35qa62vst6c8fvmnkc 
+       foreign key (group_id) 
+       references user_group;
 
-    alter table if exists users_survey 
-       add constraint FKedd4y3ae5jnsinluncc2e22u2 
+    alter table if exists user_group_admin 
+       add constraint FK44cbs8vh8ugmfgduvjb9j02kj 
        foreign key (user_id) 
        references users;
+
+    alter table if exists user_group_member 
+       add constraint FKnyc05vqmhd9hq1hv6wexhdu4t 
+       foreign key (group_id) 
+       references user_group;
+
+    alter table if exists user_group_member 
+       add constraint FKjbhg45atfwht2ji7xu241m4qp 
+       foreign key (user_id) 
+       references users;
+
+    alter table if exists user_group_permission 
+       add constraint FKao3eqnwgryopngpoq65744h2m 
+       foreign key (group_id) 
+       references user_group;
+
+    alter table if exists user_group_permission 
+       add constraint FKep4hjlw1esp4s8p3row2syxjq 
+       foreign key (survey_id) 
+       references survey;

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -1,4 +1,17 @@
 
+    create table action_rule (
+       id uuid not null,
+        classifiers bytea not null,
+        has_triggered BOOLEAN DEFAULT false not null,
+        pack_code varchar(255),
+        print_supplier varchar(255),
+        template jsonb,
+        trigger_date_time timestamp with time zone,
+        type varchar(255),
+        collection_exercise_id uuid,
+        primary key (id)
+    );
+
     create table cases (
        id uuid not null,
         address_invalid BOOLEAN DEFAULT false not null,
@@ -18,8 +31,8 @@
        id  bigserial not null,
         batch_id uuid,
         batch_quantity int4 not null,
+        action_rule_id uuid,
         caze_id uuid,
-        wave_of_contact_id uuid,
         primary key (id)
     );
 
@@ -130,23 +143,15 @@
        user_id uuid not null,
         surveys_id uuid not null
     );
-
-    create table wave_of_contact (
-       id uuid not null,
-        classifiers bytea not null,
-        has_triggered BOOLEAN DEFAULT false not null,
-        pack_code varchar(255),
-        print_supplier varchar(255),
-        template jsonb,
-        trigger_date_time timestamp with time zone,
-        type varchar(255),
-        collection_exercise_id uuid,
-        primary key (id)
-    );
 create index cases_case_ref_idx on cases (case_ref);
 
     alter table if exists users_survey 
        add constraint UK_6m5sfm18vispsa7os6vhrt09r unique (surveys_id);
+
+    alter table if exists action_rule 
+       add constraint FK6twtf1ksysh99e4g2ejmoy6c1 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
 
     alter table if exists cases 
        add constraint FKrl77p02uu7a253tn2ro5mitv5 
@@ -154,14 +159,14 @@ create index cases_case_ref_idx on cases (case_ref);
        references collection_exercise;
 
     alter table if exists case_to_process 
+       add constraint FKmqcrb58vhx7a7qcyyjjvm1y31 
+       foreign key (action_rule_id) 
+       references action_rule;
+
+    alter table if exists case_to_process 
        add constraint FK104hqblc26y5xjehv2x8dg4k3 
        foreign key (caze_id) 
        references cases;
-
-    alter table if exists case_to_process 
-       add constraint FKao8gf723128xjhos3vjh2h475 
-       foreign key (wave_of_contact_id) 
-       references wave_of_contact;
 
     alter table if exists collection_exercise 
        add constraint FKrv1ksptm37exmrbj0yutm6fla 
@@ -207,8 +212,3 @@ create index cases_case_ref_idx on cases (case_ref);
        add constraint FKedd4y3ae5jnsinluncc2e22u2 
        foreign key (user_id) 
        references users;
-
-    alter table if exists wave_of_contact 
-       add constraint FKcdvs1vhl3wiurb8w4o1h67gib 
-       foreign key (collection_exercise_id) 
-       references collection_exercise;


### PR DESCRIPTION
# Motivation and Context
Print templates are only appropriate for the surveys which have the relevant data in the sample, and as such should be restricted to only valid choices.

# What has changed
Added tables for restricting choices to only valid choices.

# How to test?
Run ATs.

# Links
Trello: https://trello.com/c/o2vCZafV