### PR TITLE
Upgrade to Hibernate 5.4.32.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.4.15.Final</version>
+      <version>5.4.32.Final</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>


### PR DESCRIPTION
# Motivation and Context
We were running on a version of Spring Boot from May 2020.

# What has changed
Upgraded to the latest and greatest Spring Boot.

# How to test?
Run the ATs. Should be zero regression.

# Links
Trello: https://trello.com/c/8MZx3DE9