### PR TITLE
Allow sample with different delimiter & no header to be loaded

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -131,7 +131,9 @@
     create table survey (
        id uuid not null,
         name varchar(255),
+        sample_separator char(1),
         sample_validation_rules jsonb,
+        sample_with_header_row boolean,
         primary key (id)
     );
 


### PR DESCRIPTION
# Motivation and Context
We can't currently load business samples into _Strategic_ Survey Data Collection, because we insist on there being a header row, and we expect regular vanilla CSV (C standing for comma, not colon).

# What has changed
Added flag to indicate sample has no header row, and configurable sample file seperator.

# How to test?
Try loading a business sample.

# Links
Trello: https://trello.com/c/Ies3dYbl