### PR TITLE
Switch to Google PubSub

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -121,6 +121,13 @@
         primary key (id)
     );
 
+    create table message_to_send (
+       id uuid not null,
+        destination_topic varchar(255),
+        message_body bytea,
+        primary key (id)
+    );
+
     create table print_template (
        pack_code varchar(255) not null,
         print_supplier varchar(255),


### PR DESCRIPTION
# Motivation and Context
We wanted to get rid of RabbitMQ because it's not cloud native, and it's therefore a pain to support and maintain in the cloud, plus we needed to migrate away from classic queues anyway, so why not just switch to Google PubSub, given that we're hosted in GCP?

# What has changed
Replaced RabbitMQ with Google PubSub.

# How to test?
Build the Case Processor, Case API, Support Tool and Print File Service. Run docker dev `make up` and then run acceptance tests `make test`

# Links
Trello: https://trello.com/c/W86A71JQ