### PR TITLE
Replace Queue With Subscription

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -127,7 +127,6 @@
        id uuid not null,
         destination_topic varchar(255),
         message_body bytea,
-        send_to_our_project boolean,
         primary key (id)
     );
 

--- a/groundzero_ddl/exceptionmanager.sql
+++ b/groundzero_ddl/exceptionmanager.sql
@@ -16,9 +16,9 @@
         headers jsonb,
         message_hash varchar(255),
         message_payload bytea,
-        queue varchar(255),
         routing_key varchar(255),
         service varchar(255),
         skipped_timestamp timestamp with time zone,
+        subscription varchar(255),
         primary key (id)
     );


### PR DESCRIPTION
# Motivation and Context
Since changing to pub/sub, terminology is out of date so queue needs to become subscription

# What has changed
Changed queue to subscription

# Links
https://trello.com/c/XPwwUY31