### PR TITLE
Use fully qualified Pub/Sub topic and subscription names

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -127,7 +127,6 @@
        id uuid not null,
         destination_topic varchar(255),
         message_body bytea,
-        send_to_our_project boolean,
         primary key (id)
     );
 


### PR DESCRIPTION
# Motivation and Context
Having completely separate config for the PubSubTemplate for our project, shared project and emulator too, created a lot of config code to have to manage. It turns out that it was nearly all redundant: we just needed to use fully qualified topic and subscription names, to specify specific projects.

# What has changed
Refactored to use fully qualified names of topics and subscriptions, where they exist outside our project.

# How to test?
Zero regression in any of the tests. Can connect to your GCP project too, if you fiddle with the config to point at your GCP project (see README).

# Links
Trello: https://trello.com/c/Wp6A6wc2