### PR TITLE
Use shared db entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ To run:
 It's very important that the DDL script to build ground zero is run, instead of manually editing the files in the `groundzero_ddl` directory, so that the database is always perfectly in sync with the code on the master branch.
 
 If you have made changes to Action Scheduler, Case Processor, Exception Manager or the UAC-QID Service and you need to re-generate the ground zero DDL, you can specify specific branches with the following options:
-- `CASE_PROCESSOR_BRANCH`
+- `SHARED_ENTITIES_BRANCH`
 - `UAC_QID_SERVICE_BRANCH`
 - `EXCEPTION_MANAGER_BRANCH`
 
-For example, you might want to run `CASE_PROCESSOR_BRANCH=example-branch build_groundzero_ddl.sh` to get the groundzero DDL to be generated for an as-yet unmerged branch called `example-branch`.
+For example, you might want to run `SHARED_ENTITIES_BRANCH=example-branch build_groundzero_ddl.sh` to get the groundzero DDL to be generated for an as-yet unmerged branch called `example-branch`.
 
 Once you have run the the `build_groundzero_ddl.sh` script, you will be able to see any differences between the old and the new DDL in Git, and create patch script(s) accordingly.
 

--- a/build_groundzero_ddl.sh
+++ b/build_groundzero_ddl.sh
@@ -8,11 +8,11 @@ rm -rf temp_clone
 mkdir temp_clone
 cd temp_clone
 
-if [ -z "$CASE_PROCESSOR_BRANCH" ]; then
-  git clone https://github.com/ONSdigital/ssdc-rm-caseprocessor.git
+if [ -z "$SHARED_ENTITIES_BRANCH" ]; then
+  git clone https://github.com/ONSdigital/ssdc-rm-common-entity-model.git
 else
-  echo "Cloning Case Processor branch $CASE_PROCESSOR_BRANCH"
-  git clone --branch $CASE_PROCESSOR_BRANCH https://github.com/ONSdigital/ssdc-rm-caseprocessor.git
+  echo "Cloning Shared Entities branch $SHARED_ENTITIES_BRANCH"
+  git clone --branch $SHARED_ENTITIES_BRANCH https://github.com/ONSdigital/ssdc-rm-common-entity-model.git
 fi
 
 if [ -z "$UAC_QID_SERVICE_BRANCH" ]; then
@@ -31,8 +31,11 @@ fi
 
 cd ..
 
-mkdir -p git_cloned_src/uk/gov/ons/ssdc/caseprocessor/model/entity
-cp temp_clone/ssdc-rm-caseprocessor/src/main/java/uk/gov/ons/ssdc/caseprocessor/model/entity/* git_cloned_src/uk/gov/ons/ssdc/caseprocessor/model/entity
+mkdir -p git_cloned_src/uk/gov/ons/ssdc/common/model/entity
+cp temp_clone/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/* git_cloned_src/uk/gov/ons/ssdc/common/model/entity
+
+mkdir -p git_cloned_src/uk/gov/ons/ssdc/common/validation
+cp temp_clone/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/validation/* git_cloned_src/uk/gov/ons/ssdc/common/validation
 
 mkdir -p git_cloned_src/uk/gov/ons/ssdc/uacqid/model/entity
 cp temp_clone/ssdc-rm-uac-qid-service/src/main/java/uk/gov/ons/ssdc/uacqid/model/entity/*.java git_cloned_src/uk/gov/ons/ssdc/uacqid/model/entity
@@ -46,6 +49,6 @@ mvn clean package
 
 rm -rf git_cloned_src
 
-java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar casev3 uk.gov.ons.ssdc.caseprocessor.model.entity
+java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar casev3 uk.gov.ons.ssdc.common.model.entity
 java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar uacqid uk.gov.ons.ssdc.uacqid.model.entity
 java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar exceptionmanager uk.gov.ons.ssdc.exceptionmanager.model.entity

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,11 @@
       <version>5.4.32.Final</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.9</version>
+    </dependency>
+    <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <version>1.18.6</version>


### PR DESCRIPTION
# Motivation and Context
Having to copy-paste changes across 5 different repos is an error prone, manual and time-consuming process.

# What has changed
Moved all the shared entities out into another repo and brought them in as a dependency stored in Artifact Registry.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/1DV95GEt