### PR TITLE
Record user who quarantined message for audit trail

### DIFF
--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (0, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (100, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.1.0', current_timestamp);

--- a/groundzero_ddl/exceptionmanager.sql
+++ b/groundzero_ddl/exceptionmanager.sql
@@ -19,6 +19,7 @@
         routing_key varchar(255),
         service varchar(255),
         skipped_timestamp timestamp with time zone,
+        skipping_user varchar(255),
         subscription varchar(255),
         primary key (id)
     );

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches/main')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.0.0'
+current_version = 'v1.1.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/main/100_add_skipping_user_column_to_quarantined_messages.sql
+++ b/patches/main/100_add_skipping_user_column_to_quarantined_messages.sql
@@ -1,0 +1,2 @@
+ALTER TABLE exceptionmanager.quarantined_message
+    ADD COLUMN IF NOT EXISTS skipping_user varchar(255);


### PR DESCRIPTION
# Motivation and Context
We want an audit trail of who quarantined messages.

# What has changed
Did a best attempt at linking the user who originally requested that a message be 'skipped' to the eventual implementation of that request by the Exception Manager. User is recorded in a `skipping_user` database column in the `quarantined_message` table.

# How to test?
Create a bad message, either using the docker dev `publish_message.sh` script locally, or by publishing directly to a topic in GCP. Then, use the support tool to skip a message. Also, try skipping a message using the toolbox bad message wizard. Check the database - it should have recorded the user who skipped the message!

# Links
Trello: https://trello.com/c/JNPHZeos