### PR TITLE
Fulfilments use correct correlation ID and originating user

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -98,6 +98,8 @@
        id  bigserial not null,
         batch_id uuid,
         batch_quantity int4,
+        correlation_id uuid not null,
+        originating_user varchar(255),
         caze_id uuid not null,
         print_template_pack_code varchar(255) not null,
         primary key (id)

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (200, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.2.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.2.0'
+current_version = 'v1.3.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/300_add_correlation_and_user_to_fulfilment_table.sql
+++ b/patches/300_add_correlation_and_user_to_fulfilment_table.sql
@@ -1,0 +1,13 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 300
+-- Purpose: Add correlation ID and originating user columns to fulfilment_to_process table
+-- Author: Nick Grant
+-- ****************************************************************************
+
+ALTER TABLE casev3.fulfilment_to_process
+    ADD COLUMN IF NOT EXISTS correlation_id uuid not null;
+
+ALTER TABLE casev3.fulfilment_to_process
+    ADD COLUMN IF NOT EXISTS originating_user varchar(255);


### PR DESCRIPTION
# Motivation and Context
We should be able to correlate a fulfilment _request_ with the subsequent printing of it, which happens when fulfilments trigger.

# What has changed
Stored the correlation ID and originating user against fulfilments in the table where they are held, waiting until the trigger time arrives.

# How to test?
Run the ATs. Try using the Support Tool to request a paper fulfilment.

# Links
Trello: https://trello.com/c/v3nc5EHo