### PR TITLE
rename survey launch to eq launch

### DIFF
--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -28,7 +28,7 @@
         sample jsonb,
         sample_sensitive jsonb,
         secret_sequence_number serial,
-        survey_launched BOOLEAN DEFAULT false not null,
+        eq_launched BOOLEAN DEFAULT false not null,
         collection_exercise_id uuid not null,
         primary key (id)
     );


### PR DESCRIPTION
Why?
"survey launch" is misleading, because a survey is a set of collection exercises, and a set of collection instruments... what we're really talking about is a specific electronic questionnaire launch (which could be either Blaise or EQ).
We need to rename the topic, subscription, listener in case processor and all associated gubbins.

What?
survey launch changed to eq launch in all occurrences

How test?
`ctrl-f` for surveyLaunch(ed), survey-launch, survey_launch - should be zero occurrences found
Build images from all the branches on the ticket
Run ATs using branch on the ticket

Links?
https://trello.com/c/hOoco1AN/2752-rename-surveylaunch-to-eqlaunch-5