### PR TITLE
2787 Add unique constraint to group name

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -241,6 +241,9 @@ set schema 'casev3';
     );
 create index cases_case_ref_idx on cases (case_ref);
 
+    alter table if exists user_group 
+       add constraint UK_kas9w8ead0ska5n3csefp2bpp unique (name);
+
     alter table if exists users 
        add constraint users_email_idx unique (email);
 

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -239,6 +239,9 @@
     );
 create index cases_case_ref_idx on cases (case_ref);
 
+    alter table if exists user_group 
+       add constraint UK_kas9w8ead0ska5n3csefp2bpp unique (name);
+
     alter table if exists users 
        add constraint users_email_idx unique (email);
 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,6 +3,6 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);
 

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.3.0'
+current_version = 'v1.4.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/400_add_unqiue_constraint_to_group_name.sql
+++ b/patches/400_add_unqiue_constraint_to_group_name.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 400
+-- Purpose: Add unique constraint to group name
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+alter table if exists user_group
+   add constraint UK_kas9w8ead0ska5n3csefp2bpp unique (name);

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>3.3.0-SNAPSHOT</version>
+  <version>3.4.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/UserGroup.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/UserGroup.java
@@ -15,7 +15,7 @@ import lombok.ToString;
 public class UserGroup {
   @Id private UUID id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, unique = true)
   private String name;
 
   @OneToMany(mappedBy = "group")


### PR DESCRIPTION
# Motivation and Context
Neither the UI nor back end should allow duplicate permissions, groups or memberships. 

# What has changed
- Add unique constraint to group name

# How to test?
Try to create duplicate groups, permissions or memberships either with the UI or API directly.

# Links
https://trello.com/c/uMBMYfs8/2787-support-tool-duplicate-permissions

