### PR TITLE
Add new script to copy out and restore user permissions after ground …

### DIFF
--- a/groundzero_ddl/ground_zero_and_restore_user_pemissions.sh
+++ b/groundzero_ddl/ground_zero_and_restore_user_pemissions.sh
@@ -6,11 +6,15 @@ PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.cr
 echo "begin transaction;" > copy_out_tables.sql
 echo "begin transaction;" > copy_in_tables.sql
 
-for TABLE_NAME in users user_group user_group_permission user_group_member user_group_admin
+for TABLE_NAME in users user_group user_group_member user_group_admin
 do
   echo "\copy casev3.$TABLE_NAME to backup_$TABLE_NAME.txt;" >> copy_out_tables.sql
   echo "\copy casev3.$TABLE_NAME from backup_$TABLE_NAME.txt;" >> copy_in_tables.sql
 done
+
+#Only copy the global permissions from the user_group_permission table, as survey specific permissions will no longer work
+echo "\copy (select * from casev3.user_group_permission where survey_id is null) to backup_user_group_permission.txt;" >> copy_out_tables.sql
+echo "\copy casev3.user_group_permission from backup_user_group_permission.txt;" >> copy_in_tables.sql
 
 echo "commit transaction;" >> copy_out_tables.sql
 echo "commit transaction;" >> copy_in_tables.sql


### PR DESCRIPTION
# Motivation and Context
New script to restore user permissions for Support Tool and ROps after ground zeroing

# What has changed
New script copies out the user permissions to file, runs the original ground zero script then copies them back in.

# How to test?
- Add some user permissions (roles, groups etc.) then run this script to ground zero.  The permissions should still be there after ground zeroing.

# Links
- https://trello.com/c/RjKMGFww

