### PR TITLE
Allow unlimited length job row validation error descriptions

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -194,7 +194,7 @@ set schema 'casev3';
         original_row_data bytea not null,
         original_row_line_number int4 not null,
         row_data jsonb,
-        validation_error_descriptions varchar(255),
+        validation_error_descriptions bytea,
         job_id uuid not null,
         primary key (id)
     );

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -192,7 +192,7 @@
         original_row_data bytea not null,
         original_row_line_number int4 not null,
         row_data jsonb,
-        validation_error_descriptions varchar(255),
+        validation_error_descriptions bytea,
         job_id uuid not null,
         primary key (id)
     );

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.3.0'
+current_version = 'v1.4.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/400_allow_long_job_row_errors.sql
+++ b/patches/400_allow_long_job_row_errors.sql
@@ -1,0 +1,11 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 400
+-- Purpose: Allow job row validation errors to be [almost] infinitely long
+-- Author: Nick Grant
+-- ****************************************************************************
+
+ALTER TABLE casev3.job_row
+    ALTER COLUMN validation_error_descriptions TYPE bytea
+        USING validation_error_descriptions::bytea;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.5.0-SNAPSHOT</version>
+  <version>4.6.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/JobRow.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/JobRow.java
@@ -8,6 +8,7 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Id;
+import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import lombok.Data;
 import org.hibernate.annotations.Type;
@@ -37,5 +38,24 @@ public class JobRow {
   @Column(nullable = false)
   private JobRowStatus jobRowStatus;
 
-  @Column private String validationErrorDescriptions;
+  @Lob
+  @Type(type = "org.hibernate.type.BinaryType")
+  @Column
+  private byte[] validationErrorDescriptions;
+
+  public void setValidationErrorDescriptions(String validationErrorDescriptionsStr) {
+    if (validationErrorDescriptionsStr == null) {
+      validationErrorDescriptions = null;
+    } else {
+      validationErrorDescriptions = validationErrorDescriptionsStr.getBytes();
+    }
+  }
+
+  public String getValidationErrorDescriptions() {
+    if (validationErrorDescriptions == null) {
+      return null;
+    }
+
+    return new String(validationErrorDescriptions);
+  }
 }


### PR DESCRIPTION
# Motivation and Context
If a row in a CSV file has a lot of problems, it could easily exceed the current 255 character limit for the error description(s).

# What has changed
Swapped the type from `varchar(255)` to `bytea` so that there's no limit on the `validation_error_descriptions` column.

# How to test?
Set up a load of rules on a load of columns, then try to load in data which violates all those rules... as many as possible on a single row, to ensure that the error description is exceptionally long.

# Links
Trello: https://trello.com/c/Rwv4wxTa