### PR TITLE
3013 Enhance ground zero script to replace DB permissions

### DIFF
--- a/groundzero_ddl/ground_zero_and_restore_user_pemissions.sh
+++ b/groundzero_ddl/ground_zero_and_restore_user_pemissions.sh
@@ -1,18 +1,20 @@
-cd groundzero_ddl
+# Make sure we're working in the right directory
+cd groundzero_ddl || true
 
 PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=${DB_PASSWORD:=password} dbname=$DB_NAME"
 
-#Create the copy in/out files and run the copy out
+# Create the copy in/out files and run the copy out
 echo "begin transaction;" > copy_out_tables.sql
 echo "begin transaction;" > copy_in_tables.sql
 
+# Copy out all the non survey specific user and group tables
 for TABLE_NAME in users user_group user_group_member user_group_admin
 do
   echo "\copy casev3.$TABLE_NAME to backup_$TABLE_NAME.txt;" >> copy_out_tables.sql
   echo "\copy casev3.$TABLE_NAME from backup_$TABLE_NAME.txt;" >> copy_in_tables.sql
 done
 
-#Only copy the global permissions from the user_group_permission table, as survey specific permissions will no longer work
+# Only copy the global permissions from the user_group_permission table, as survey specific permissions will no longer work
 echo "\copy (select * from casev3.user_group_permission where survey_id is null) to backup_user_group_permission.txt;" >> copy_out_tables.sql
 echo "\copy casev3.user_group_permission from backup_user_group_permission.txt;" >> copy_in_tables.sql
 
@@ -21,13 +23,13 @@ echo "commit transaction;" >> copy_in_tables.sql
 
 psql "$PSQL_CONNECT_WRITE_MODE" -f copy_out_tables.sql
 
-#Run the ground zero
+# Run the ground zero
 . rebuild_from_ground_zero.sh
 
-#Restore the tables
+# Restore the tables
 psql "$PSQL_CONNECT_WRITE_MODE" -f copy_in_tables.sql
 
-#Remove all table files
+# Remove all table files
 for TABLE_NAME in users user_group user_group_permission user_group_member user_group_admin
 do
   rm backup_$TABLE_NAME.txt
@@ -36,5 +38,8 @@ done
 rm copy_out_tables.sql
 rm copy_in_tables.sql
 
-
-
+# Restore database role permissions which are lost when the tables are removed and recreated
+for PERMISSIONS_SCRIPT in ../permissions/*.sql;
+do
+  psql "$PSQL_CONNECT_WRITE_MODE" -f "$PERMISSIONS_SCRIPT"
+done

--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -1,4 +1,5 @@
-cd groundzero_ddl
+# Make sure we're working in the right directory
+cd groundzero_ddl || true
 
 PSQL_CONNECT_WRITE_MODE="sslmode=verify-ca sslrootcert=/root/.postgresql/root.crt sslcert=/root/.postgresql/postgresql.crt sslkey=/root/.postgresql/postgresql.key hostaddr=$DB_HOST user=rmuser password=${DB_PASSWORD:=password} dbname=$DB_NAME"
 

--- a/permissions/RM-Developer-Permissions.sql
+++ b/permissions/RM-Developer-Permissions.sql
@@ -1,14 +1,18 @@
 -- ********************************************
 -- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
 -- ********************************************
--- *** Number: 0012                         ***
--- *** Purpose: Create and grant            *** 
+-- *** Purpose: Create and grant            ***
 -- *** permissions on rm dev group role     ***
 -- ***                                      ***
 -- *** Author: Adam Hawtin                  ***
 -- ********************************************
 
+DO $$
+BEGIN
 CREATE ROLE rm_developer;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 
 GRANT CONNECT ON DATABASE rm TO rm_developer;
 

--- a/permissions/RM-Read-Permissions.sql
+++ b/permissions/RM-Read-Permissions.sql
@@ -1,14 +1,18 @@
 -- ********************************************
 -- *** MANUAL RM SQL DATABASE UPDATE SCRIPT ***
 -- ********************************************
--- *** Number: 0010                         ***
--- *** Purpose: Create and grant            *** 
+-- *** Purpose: Create and grant            ***
 -- *** permissions on rm read only access   ***
 -- *** role                                 ***
 -- *** Author: Adam Hawtin                  ***
 -- ********************************************
 
+DO $$
+BEGIN
 CREATE ROLE rm_read_access;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 
 GRANT CONNECT ON DATABASE rm TO rm_read_access;
 

--- a/permissions/RM-Support-Permissions.sql
+++ b/permissions/RM-Support-Permissions.sql
@@ -1,4 +1,9 @@
+DO $$
+BEGIN
 CREATE ROLE rm_support;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 
 GRANT CONNECT ON DATABASE rm TO rm_support;
 

--- a/permissions/RM-Tester-Permissions.sql
+++ b/permissions/RM-Tester-Permissions.sql
@@ -1,4 +1,9 @@
+DO $$
+BEGIN
 CREATE ROLE rm_tester;
+EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%, skipping', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
 
 GRANT CONNECT ON DATABASE rm TO rm_tester;
 


### PR DESCRIPTION
# Motivation and Context
When the database tables are dropped and recreated, any permissions granted on them are lost. We need to re-run our role permission grants after the ground zero to fix this.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Run the permissions scripts in ground zero and replace users script
- Amend the permissions scripts to not fail when the role name already exists

# How to test?
Check the scripts can be re-run without failing if the role already exists. Ground zero an environment using the `ground_zero_and_restore_user_pemissions.sh` script.

# Links
https://trello.com/c/PlGbSYpB/3013-enhance-integration-ground-zero-job-replace-db-permissions-3
