### PR TITLE
Fix uac_hash column on uac_qid_link table which was supposed to be varchar(255)

### DIFF
--- a/patches/500_collection_instrument_and_uac_hash.sql
+++ b/patches/500_collection_instrument_and_uac_hash.sql
@@ -36,7 +36,7 @@ ALTER TABLE casev3.uac_qid_link ALTER COLUMN collection_instrument_url SET NOT N
 
 -- add the column
 ALTER TABLE casev3.uac_qid_link
-    ADD COLUMN IF NOT EXISTS uac_hash jsonb;
+    ADD COLUMN IF NOT EXISTS uac_hash varchar(255);
 
 -- give it a default value
 UPDATE casev3.uac_qid_link SET uac_hash = 'this is not a UAC hash because we need a data wipe';


### PR DESCRIPTION
# Motivation and Context
Another mistake copy-pasting the DB patch script.

# What has changed
Fixed the mistake.

# How to test?
Fail forward.

# Links
Trello: https://trello.com/c/jvn22Igo