### PR TITLE
Upgrade to Java 17 and Spring Boot 2.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
           - PIPENV_IGNORE_VIRTUALENVS=1
 
     - language: java
-      jdk: openjdk11
+      jdk: openjdk17
 
       before_install:
         - make format-check-common

--- a/pom.xml
+++ b/pom.xml
@@ -9,24 +9,24 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
 
   <dependencies>
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-core</artifactId>
-      <version>5.4.32.Final</version>
+      <version>5.6.1.Final</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.3.9</version>
+      <version>5.3.13</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.6</version>
+      <version>1.18.20</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -131,8 +131,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.8.1</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <source>17</source>
+          <target>17</target>
         </configuration>
       </plugin>
     </plugins>

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -11,13 +11,13 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.5.3</version>
+    <version>2.6.0</version>
     <relativePath/>
   </parent>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <distributionManagement>

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.9.0-SNAPSHOT</version>
+  <version>4.10.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -83,7 +83,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.2.0-SNAPSHOT</version>
+      <version>1.3.0-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
# Motivation and Context
Java 11 is no longer the LTS (Long-Term Support) version. Java 17 is the LTS version, so we should use that.

Spring Boot 2.6.0 is the first version of Spring Boot to support Java 17, so we should use that too.

# What has changed
Upgraded to Java 17 and Spring Boot 2.6.0, plus upped any other versions required for everything to work.

Switched the Docker base image over to be JDK 17 too.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/kcJGECdH