### PR TITLE
Global Permissions Handling

### DIFF
--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.10.0-SNAPSHOT</version>
+  <version>4.12.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/UserGroupAuthorisedActivityType.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/UserGroupAuthorisedActivityType.java
@@ -2,12 +2,12 @@ package uk.gov.ons.ssdc.common.model.entity;
 
 public enum UserGroupAuthorisedActivityType {
   SUPER_USER,
-  LIST_SURVEYS,
+  LIST_SURVEYS(true),
   VIEW_SURVEY,
-  CREATE_SURVEY,
-  CREATE_EXPORT_FILE_TEMPLATE,
-  CREATE_SMS_TEMPLATE,
-  CREATE_EMAIL_TEMPLATE,
+  CREATE_SURVEY(true),
+  CREATE_EXPORT_FILE_TEMPLATE(true),
+  CREATE_SMS_TEMPLATE(true),
+  CREATE_EMAIL_TEMPLATE(true),
   LIST_COLLECTION_EXERCISES,
   VIEW_COLLECTION_EXERCISE,
   CREATE_COLLECTION_EXERCISE,
@@ -50,12 +50,26 @@ public enum UserGroupAuthorisedActivityType {
   CREATE_CASE_EMAIL_FULFILMENT,
   UPDATE_SAMPLE,
   UPDATE_SAMPLE_SENSITIVE,
-  LIST_EXPORT_FILE_TEMPLATES,
-  LIST_EXPORT_FILE_DESTINATIONS,
-  LIST_SMS_TEMPLATES,
-  LIST_EMAIL_TEMPLATES,
-  CONFIGURE_FULFILMENT_TRIGGER,
-  EXCEPTION_MANAGER_VIEWER,
-  EXCEPTION_MANAGER_PEEK,
-  EXCEPTION_MANAGER_QUARANTINE,
+  LIST_EXPORT_FILE_TEMPLATES(true),
+  LIST_EXPORT_FILE_DESTINATIONS(true),
+  LIST_SMS_TEMPLATES(true),
+  LIST_EMAIL_TEMPLATES(true),
+  CONFIGURE_FULFILMENT_TRIGGER(true),
+  EXCEPTION_MANAGER_VIEWER(true),
+  EXCEPTION_MANAGER_PEEK(true),
+  EXCEPTION_MANAGER_QUARANTINE(true);
+
+  private boolean global;
+
+  UserGroupAuthorisedActivityType() {
+    this.global = false;
+  }
+
+  UserGroupAuthorisedActivityType(boolean global) {
+    this.global = global;
+  }
+
+  public boolean isGlobal() {
+    return global;
+  }
 }


### PR DESCRIPTION
# Motivation and Context
Global permissions need to be handled differently from survey-specific permissions. For example, being able to see the list of SMS templates is not something survey specific. As such, it's hard for our UI to know what APIs are allowed to be called.

To solve this problem, by marking global permissions as global, we can filter those permissions out when the user is a super user on a specific survey, so it doesn't confuse the UI.

# What has changed
Added `global` flag to permissions. Filtered out the global permissions for survey specific super users. Denied any requests to use global permissions on specific surveys, because that's nonsense.

There's still some UI work to do to prevent people from attempting to put global permissions on surveys, but the backend will prevent it.

# How to test?
Try it out.

# Links
Trello: https://trello.com/c/DrxN8MHD