### PR TITLE
New script to remove global permissions that hav been created against…

### DIFF
--- a/ui-permissions/remove-global-rule-where-survey-is-not-null.sql
+++ b/ui-permissions/remove-global-rule-where-survey-is-not-null.sql
@@ -6,7 +6,7 @@
 -- Author: Gavin Edwards
 -- ****************************************************************************
 
-SELECT * FROM casev3.user_group_permission
+DELETE FROM casev3.user_group_permission
 WHERE authorised_activity IN
 ('LIST_SURVEYS',
  'CREATE_SURVEY',

--- a/ui-permissions/remove-global-rule-where-survey-is-not-null.sql
+++ b/ui-permissions/remove-global-rule-where-survey-is-not-null.sql
@@ -1,0 +1,23 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Purpose: One off script to remove global group permissions that have been created against a specific survey.
+--          A future fix will prevent this from happening to begin with.
+-- Author: Gavin Edwards
+-- ****************************************************************************
+
+SELECT * FROM casev3.user_group_permission
+WHERE authorised_activity IN
+('LIST_SURVEYS',
+ 'CREATE_SURVEY',
+ 'CREATE_EXPORT_FILE_TEMPLATE',
+ 'CREATE_SMS_TEMPLATE',
+ 'CREATE_EMAIL_TEMPLATE',
+ 'LIST_EXPORT_FILE_TEMPLATES',
+ 'LIST_SMS_TEMPLATES',
+ 'LIST_EMAIL_TEMPLATES',
+ 'CONFIGURE_FULFILMENT_TRIGGER',
+ 'EXCEPTION_MANAGER_VIEWER',
+ 'EXCEPTION_MANAGER_PEEK',
+ 'EXCEPTION_MANAGER_QUARANTINE')
+AND survey_id IS NOT NULL;


### PR DESCRIPTION
# Motivation and Context
The UI previously allowed users to add a global permission to a group, but against a survey.  For example, you could add LIST_SURVEYS against a specific survey but LIST_SURVEYS is a global permission so it won't work when created against a survey.  This script removes the incorrect permissions.  A fix (currently in PR) will stop this happening in future.

# What has changed
- New script to be manually run in the db.  It removes the permission from groups where the permission is global but has been created against a survey.  
- The list of global permissions is from here: https://github.com/ONSdigital/ssdc-rm-ddl/pull/75/files

# How to test?
- Amend the script to a `SELECT *` rather than `DELETE` then run it in an environment to check that the correct rows will be deleted.

# Links
- https://trello.com/c/MPwwVCGf
