### PR TITLE
Bump log4j to 2.17.0

### DIFF
--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.12.2-SNAPSHOT</version>
+  <version>4.12.3-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
@@ -18,7 +18,7 @@
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <log4j2.version>2.16.0</log4j2.version>
+    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <distributionManagement>

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -84,7 +84,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.4.2-SNAPSHOT</version>
+      <version>1.4.3-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
# Motivation and Context
Another vulnerability in log4j means another version update.

# What has changed
Updated the version of log4j in common-entity-model

# How to test?
Build the branch of shared-sample-validation then build this one and check that it builds.

# Links
https://trello.com/c/olugyyoI
https://github.com/ONSdigital/ssdc-shared-sample-validation/pull/11
