### PR TITLE
Bump to Spring Boot 2.6.2 and remove Log4j version from pom.xml

### DIFF
--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,19 +6,18 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.12.3-SNAPSHOT</version>
+  <version>4.12.4-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.0</version>
+    <version>2.6.2</version>
     <relativePath/>
   </parent>
 
   <properties>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <log4j2.version>2.17.0</log4j2.version>
   </properties>
 
   <distributionManagement>
@@ -84,7 +83,7 @@
     <dependency>
       <groupId>uk.gov.ons.ssdc</groupId>
       <artifactId>ssdc-shared-sample-validation</artifactId>
-      <version>1.4.3-SNAPSHOT</version>
+      <version>1.4.4-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
# Motivation and Context
Tidying up after the log4j zero day.

# What has changed
Bumped Spring Boot up to 2.6.2 and removed the explicit log4j version.

# How to test?
Zero regression.

# Links
Trello: https://trello.com/c/RILwmR5e