### PR TITLE
3209 Personalisation on print fulfilment

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -160,6 +160,7 @@ set schema 'casev3';
         batch_quantity int4,
         correlation_id uuid not null,
         originating_user varchar(255),
+        personalisation jsonb,
         uac_metadata jsonb,
         caze_id uuid not null,
         export_file_template_pack_code varchar(255) not null,

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -158,6 +158,7 @@
         batch_quantity int4,
         correlation_id uuid not null,
         originating_user varchar(255),
+        personalisation jsonb,
         uac_metadata jsonb,
         caze_id uuid not null,
         export_file_template_pack_code varchar(255) not null,

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.6.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.7.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.6.0'
+current_version = 'v1.7.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/700_add_personalisation_to_fulfilment_to_process.sql
+++ b/patches/700_add_personalisation_to_fulfilment_to_process.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 700
+-- Purpose: Add personalisation JSON column to the fulfilments to process table
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.user_group
+    ADD COLUMN IF NOT EXISTS personalisation jsonb;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -96,14 +96,14 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.22</version>
       <scope>provided</scope>
     </dependency>
 
     <dependency>
       <groupId>com.vladmihalcea</groupId>
       <artifactId>hibernate-types-55</artifactId>
-      <version>2.12.1</version>
+      <version>2.14.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.13.0-SNAPSHOT</version>
+  <version>4.14.0-personalisation-on-fulfilment</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.14.0-personalisation-on-fulfilment</version>
+  <version>4.14.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.common.model.entity;
 
 import com.vladmihalcea.hibernate.type.json.JsonBinaryType;
+import java.util.Map;
 import java.util.UUID;
 import javax.persistence.*;
 import lombok.Data;
@@ -40,5 +41,5 @@ public class FulfilmentToProcess {
 
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
-  private Object personalisation;
+  private Map<String, String> personalisation;
 }

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/FulfilmentToProcess.java
@@ -37,4 +37,8 @@ public class FulfilmentToProcess {
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
   private Object uacMetadata;
+
+  @Type(type = "jsonb")
+  @Column(columnDefinition = "jsonb")
+  private Object personalisation;
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to enable print fulfilment requests to supply extra personalisation values beyond what is stored on the case. We need to store those request personalisation values in the fulfilment to process table.

# What has changed
- Add personalisation jsonb column to fulfilment to process table
- Add migration script
- Regen the various ground zero scripts

# How to test?
Check the migration script.
Build locally then build the service branches and run the AT's.

# Links
https://trello.com/c/fwLbkDJy/3209-ability-to-include-a-name-on-a-fulfilment-by-post-8
