### PR TITLE
Added new event types for refusal and data erase

### DIFF
--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.14.0-SNAPSHOT</version>
+  <version>4.15.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/EventType.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/EventType.java
@@ -4,6 +4,7 @@ public enum EventType {
   NEW_CASE,
   RECEIPT,
   REFUSAL,
+  ERASE_DATA,
   EQ_LAUNCH,
   INVALID_CASE,
   UAC_AUTHENTICATION,

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/RefusalType.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/RefusalType.java
@@ -3,5 +3,6 @@ package uk.gov.ons.ssdc.common.model.entity;
 public enum RefusalType {
   HARD_REFUSAL,
   EXTRAORDINARY_REFUSAL,
-  SOFT_REFUSAL
+  SOFT_REFUSAL,
+  WITHDRAWAL_REFUSAL
 }


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need a new refusal type for anyone whos previously agreed to take part in a survey but now wants to withdraw. We also need functionality to remove sensitive data if a respondent asks us to remove their data.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added new withdrawal refusal type
- Remove sensitive data through the refusal event.
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run with other branches and run the ATs
- Refuse a case and pass in `eraseData = true` and make sure the sensitive data in the event is removed
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/q8cx1tZn/)

