### PR TITLE
3277 - Add PMD and errorprone checks

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,10 @@
+--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
+--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
+--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test: check lint
 	pipenv run pytest
 
 format-check-common:
-	cd ssdc-rm-common-entity-model && mvn fmt:check
+	cd ssdc-rm-common-entity-model && mvn fmt:check pmd:check
 
 build-common:
 	cd ssdc-rm-common-entity-model && mvn compile

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ test: check lint
 format-check-common:
 	cd ssdc-rm-common-entity-model && mvn fmt:check pmd:check
 
+check-ddl:
+	mvn pmd:check
+
 build-common:
 	cd ssdc-rm-common-entity-model && mvn compile
 

--- a/exclude-pmd.properties
+++ b/exclude-pmd.properties
@@ -1,2 +1,5 @@
 # TODO: as a team, define our own custom PMD checker so that we don't have to keep adding piecemeal
 #       to this file
+
+uk.gov.ons.ssdc.common.validation.ColumnValidator=UseVarargs, ArrayIsStoredDirectly, MethodReturnsInternalArray
+uk.gov.ons.ssdc.common.validation.InSetRule=UseVarargs

--- a/exclude-pmd.properties
+++ b/exclude-pmd.properties
@@ -1,0 +1,2 @@
+# TODO: as a team, define our own custom PMD checker so that we don't have to keep adding piecemeal
+#       to this file

--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,29 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.16.0</version>
+        <configuration>
+          <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
+          <failurePriority>3</failurePriority>
+          <failOnViolation>true</failOnViolation>
+          <verbose>true</verbose>
+          <rulesets>
+            <ruleset>/category/java/bestpractices.xml</ruleset>
+            <ruleset>/category/java/security.xml</ruleset>
+          </rulesets>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>build-helper-maven-plugin</artifactId>
         <version>3.0.0</version>
@@ -133,10 +156,25 @@
         <configuration>
           <source>17</source>
           <target>17</target>
+          <encoding>UTF-8</encoding>
+          <compilerArgs>
+            <arg>-XDcompilePolicy=simple</arg>
+            <arg>-Xplugin:ErrorProne</arg>
+          </compilerArgs>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>com.google.errorprone</groupId>
+              <artifactId>error_prone_core</artifactId>
+              <version>2.11.0</version>
+            </path>
+            <path>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+              <version>1.18.20</version>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
     </plugins>
   </build>
-
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,7 @@
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
           <verbose>true</verbose>
+          <linkXRef>false</linkXRef>
           <rulesets>
             <ruleset>/category/java/bestpractices.xml</ruleset>
             <ruleset>/category/java/security.xml</ruleset>

--- a/src/main/java/uk/gov/ons/ssdc/rm/ddl/Application.java
+++ b/src/main/java/uk/gov/ons/ssdc/rm/ddl/Application.java
@@ -14,6 +14,7 @@ import org.hibernate.dialect.PostgreSQL94Dialect;
 import org.hibernate.tool.hbm2ddl.SchemaExport;
 import org.hibernate.tool.schema.TargetType;
 
+@SuppressWarnings("PMD")
 public class Application {
 
   private static final String OUTPUT_DIRECTORY = "groundzero_ddl";

--- a/ssdc-rm-common-entity-model/exclude-pmd.properties
+++ b/ssdc-rm-common-entity-model/exclude-pmd.properties
@@ -1,0 +1,2 @@
+# TODO: as a team, define our own custom PMD checker so that we don't have to keep adding piecemeal
+#       to this file

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -65,6 +65,30 @@
     </extensions>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-pmd-plugin</artifactId>
+        <version>3.16.0</version>
+        <configuration>
+          <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
+          <failurePriority>3</failurePriority>
+          <failOnViolation>true</failOnViolation>
+          <verbose>true</verbose>
+          <linkXRef>false</linkXRef>
+          <rulesets>
+            <ruleset>/category/java/bestpractices.xml</ruleset>
+            <ruleset>/category/java/security.xml</ruleset>
+          </rulesets>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>compile</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>com.coveo</groupId>
         <artifactId>fmt-maven-plugin</artifactId>
         <version>2.8</version>


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We can introduce PMD and ErrorProne code analysis/compile tools to our Java apps. Drawing from [this spike branch](https://github.com/ONSdigital/ssdc-rm-response-operations/pull/78/files) and adding some additional bits.

I’ve put a `<failurePriority>`  of `3` for PMD (scale of 1 - 5, with `1` being 'severe'), so it will fail on anything over a medium level severity. Anything below this level will output as a warning. I’ve set it at a level that seems sensible, but it’s debatable!

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
* Add PMD ignore file for code to be ignored for now, but to investigate later 
* Fix some errors & warnings from PMD
* Add `check` target to Makefile
* Update Travis checks

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
* If you want to see some of the PMD failures, comment out the lines in `exclude-pmd.propeties` file.
* Run something like `make dev-build` to kick off the checks
* Check to see the tools pick up the issues as expected
* Run ATs, should still pass.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Y4aAAwHb/3277-java-checks-8