### PR TITLE
408 Add uacqid and ddl schemas to dev postgres init generation

### DIFF
--- a/build_init_script.sh
+++ b/build_init_script.sh
@@ -4,3 +4,17 @@ echo "create schema if not exists casev3;"
 echo "set schema 'casev3';"
 cat groundzero_ddl/casev3.sql
 } > dev-common-postgres-image/init.sql
+
+{
+echo ""
+echo "create schema if not exists uacqid;"
+echo "set schema 'uacqid';"
+cat groundzero_ddl/uacqid.sql
+} >> dev-common-postgres-image/init.sql
+
+{
+echo ""
+echo "create schema if not exists ddl_version;"
+echo "set schema 'ddl_version';"
+cat groundzero_ddl/ddl_version.sql
+} >> dev-common-postgres-image/init.sql

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -454,3 +454,23 @@ create index cases_case_ref_idx on cases (case_ref);
        add constraint FKep4hjlw1esp4s8p3row2syxjq 
        foreign key (survey_id) 
        references survey;
+
+create schema if not exists uacqid;
+set schema 'uacqid';
+
+    create table uac_qid (
+       uac varchar(255) not null,
+        qid varchar(255),
+        unique_number serial,
+        primary key (uac)
+    );
+
+create schema if not exists ddl_version;
+set schema 'ddl_version';
+CREATE TABLE ddl_version.patches (patch_number integer PRIMARY KEY, applied_timestamp timestamp with time zone NOT NULL);
+CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_timestamp timestamp with time zone NOT NULL);
+
+-- Version and patch number for the current ground zero,
+-- NOTE: These must be updated every time the repo is tagged
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (900, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.9.0', current_timestamp);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The dev postgres image needs the uacqid and ddl_version schemas.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add uacqid and ddl_version schemas to dev postgres init generation
- Regenerate dev postgres init sql

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Run `make dev-build` to rebuild the dev postgres image, check docker dev still works as normal.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/Zyj3PlNA/408-spike-how-do-we-handle-ddl-setup-change-in-prod-2-days

