### PR TITLE
460 Fix export file row length limitation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 <!--- Why is this change required? What problem does it solve? -->
 
 # Has the DDL schema changed?
-*Pull requests which include schema changes should be labelled with the `schema change` label for visibility
+*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*
 * [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema version: <!---Add the new schema version number if it has changes-->
 
 # What has changed

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -118,7 +118,7 @@ set schema 'casev3';
         batch_quantity int4 not null,
         export_file_destination varchar(255) not null,
         pack_code varchar(255) not null,
-        row varchar(255) not null,
+        row varchar(5000) not null,
         primary key (id)
     );
 
@@ -504,5 +504,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (900, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.9.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1000, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.10.0', current_timestamp);

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -112,7 +112,7 @@
         batch_quantity int4 not null,
         export_file_destination varchar(255) not null,
         pack_code varchar(255) not null,
-        row varchar(255) not null,
+        row varchar(5000) not null,
         primary key (id)
     );
 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -3,5 +3,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (900, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.9.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1000, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.10.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # current_version should match the version in the ddl_version.sql file
-current_version = 'v1.9.0'
+current_version = 'v1.10.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1000_increase_length_of_export_file_row.sql
+++ b/patches/1000_increase_length_of_export_file_row.sql
@@ -1,0 +1,9 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 1000
+-- Purpose: Increase export file 'row' column length to 5000
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.export_file_row ALTER COLUMN row TYPE VARCHAR(5000);

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.16.2-SNAPSHOT</version>
+  <version>4.16.3-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ExportFileRow.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ExportFileRow.java
@@ -17,7 +17,7 @@ public class ExportFileRow {
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private long id;
 
-  @Column(nullable = false)
+  @Column(nullable = false, length = 5000)
   private String row;
 
   @Column(nullable = false)


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The export file 'row' column needs to be able to store entire CSV rows, it was being limited to the hibernate default of 255 characters which is not sufficient.

# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*
* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema version: `v1.10.0`

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Set the export file row `row` field `length` to 5000 in hibernate model
- Regenerate DDL
- Add migration script
- Bump version number

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the generated DDL change make sense
To test locally:
- Run the docker dev branch checkout/build script against this branch
- Spin up docker dev, load a random sample with some data, make a long export file template which will end up exceeding 255 characters for at least some cases
- Run an export file action rule using this template
- Check the action rule goes through and produces the export file with long rows without issue

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
https://trello.com/c/DOof0YY5/460-spike-export-file-rows-break-if-they-exceed-255-characters-in-length-1-day
