### PR TITLE
Update dev postgres image to prepare for new user changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,12 @@ jobs:
       dist: bionic # The default dist does not yet support python 3.10
       name: "Python Tests and Checks"
 
+      before_install:
+        - deactivate # Deactivate the virtualenv Travis dumps us in, so that we can fix out of date global dependencies
+        - pyenv global 3.10 # Ensure the right global python version is being used
+        - pip install --upgrade pip pipenv setuptools wheel
 
       install:
-        - pip uninstall -y numpy  # Remove the vulnerable Numpy which Travis provides
-        - pip install -U pipenv
         - pipenv install --dev --deploy
 
       script:
@@ -40,10 +42,11 @@ jobs:
       before_install:
         - docker login -u "${DOCKER_GCP_USERNAME}" -p "${GOOGLE_SERVICE_ACCOUNT_KEY}" https://europe-west2-docker.pkg.dev;
         - docker login -u "${DOCKERHUB_USERNAME}" -p "${DOCKERHUB_PASSWORD}";
+        - deactivate # Deactivate the virtualenv Travis dumps us in, so that we can fix out of date global dependencies
+        - pyenv global 3.10 # Ensure the right global python version is being used
+        - pip install --upgrade pip pipenv setuptools wheel
 
       install:
-        - pip uninstall -y numpy  # Remove the vulnerable Numpy which Travis provides
-        - pip install -U pipenv
         - pipenv install --dev --deploy
 
       script:

--- a/build_init_script.sh
+++ b/build_init_script.sh
@@ -3,6 +3,7 @@ rm dev-common-postgres-image/init.sql || true
 echo "-- THIS FILE IS AUTO-GENERATED"
 echo "-- DO NOT EDIT IT DIRECTLY"
 echo "-- REFER TO THE README FOR INSTRUCTIONS ON REGENERATING IT"
+cat dev-common-postgres-image/dev-init.sql
 echo ""
 echo "create schema if not exists casev3;"
 echo "set schema 'casev3';"
@@ -13,7 +14,7 @@ echo "set schema 'uacqid';"
 cat groundzero_ddl/uacqid.sql
 echo ""
 echo "create schema if not exists exceptionmanager;"
-echo "set schema 'uacqid';"
+echo "set schema 'exceptionmanager';"
 cat groundzero_ddl/exceptionmanager.sql
 echo ""
 echo "create schema if not exists ddl_version;"

--- a/dev-common-postgres-image/Dockerfile
+++ b/dev-common-postgres-image/Dockerfile
@@ -1,7 +1,7 @@
 FROM postgres:13-buster
 
-ENV POSTGRES_USER postgres
+ENV POSTGRES_USER appuser
 ENV POSTGRES_PASSWORD postgres
-ENV POSTGRES_DB postgres
+ENV POSTGRES_DB rm
 
 COPY init.sql /docker-entrypoint-initdb.d/

--- a/dev-common-postgres-image/dev-init.sql
+++ b/dev-common-postgres-image/dev-init.sql
@@ -1,0 +1,13 @@
+
+-- The following statements are required to allow the patch 600 to run against a local dev postgres container
+DO $$
+BEGIN
+    CREATE USER appuser;
+    EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+ALTER ROLE appuser WITH PASSWORD 'postgres';
+CREATE ROLE cloudsqlsuperuser;
+GRANT cloudsqlsuperuser TO appuser;
+ALTER ROLE appuser WITH CREATEDB;
+ALTER ROLE appuser WITH CREATEROLE;

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -2,6 +2,19 @@
 -- DO NOT EDIT IT DIRECTLY
 -- REFER TO THE README FOR INSTRUCTIONS ON REGENERATING IT
 
+-- The following statements are required to allow the patch 600 to run against a local dev postgres container
+DO $$
+BEGIN
+    CREATE USER appuser;
+    EXCEPTION WHEN duplicate_object THEN RAISE NOTICE '%', SQLERRM USING ERRCODE = SQLSTATE;
+END
+$$;
+ALTER ROLE appuser WITH PASSWORD 'postgres';
+CREATE ROLE cloudsqlsuperuser;
+GRANT cloudsqlsuperuser TO appuser;
+ALTER ROLE appuser WITH CREATEDB;
+ALTER ROLE appuser WITH CREATEROLE;
+
 create schema if not exists casev3;
 set schema 'casev3';
 
@@ -471,7 +484,7 @@ set schema 'uacqid';
     );
 
 create schema if not exists exceptionmanager;
-set schema 'uacqid';
+set schema 'exceptionmanager';
 
     create table auto_quarantine_rule (
        id uuid not null,
@@ -504,6 +517,7 @@ CREATE TABLE ddl_version.patches (patch_number integer PRIMARY KEY, applied_time
 CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_timestamp timestamp with time zone NOT NULL);
 
 -- Version and patch number for the current ground zero,
+-- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
 INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (500, current_timestamp);
 INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.5', current_timestamp);


### PR DESCRIPTION
# Motivation and Context
A new user will be added to our database to limit permissions of the apps. This requires a patch that references the DB name `rm` and the new user `appuser`, which are both created by terraform and as such don't exist in our dev image. This causes the patch tests to fail.

To fix this a new dev-common-postgres image must be built first that contains an `rm` database and an `appuser` user so that the travis build for a second PR adding the patch in will pass.

# What has changed
Added an extra step to the `build_init_script.sh` script that adds SQL to create a user with dummy permissions that will allow the patch to be applied against it and updated the docker file.
