### PR TITLE
updating jackson dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.9</version>
+      <version>2.12.7</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10.8</version>
+      <version>2.12.7.1</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cobertura</groupId>


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It looks like we need to update both jackson dependencies to get the ddl working as expected.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
Updated both jackson dependencies
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Run make dev-build and everything should work as expected.
- If you revert jackson-core back to version 2.9.9 and run make dev-build, you'll see it won't build the sql files but complain about  JacksonFeature not being there.
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/q9Cv4jsl/

