### PR TITLE
Added patch to update replacement UAC templates

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -608,8 +608,8 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('NE_CY_CRIS', 'CRIS Notification - Bilingual Welsh', 'acd97184-b282-4ff9-98cf-ba14bf74c2f8', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_EN_CRIS', 'CRIS Reminder - English', '8cf30001-0c06-4da4-b49d-1df975a1123a', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_CY_CRIS', 'CRIS Reminder - Bilingual Welsh', '42af756c-7239-4486-b67d-ce2c6c4a7f9b', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
-('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
+('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"]'),
+('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"]'),
 ('RE_UAC_EN_CRIS', 'CRIS Reminder with UAC - English', 'd0224400-4894-4bdd-b0bc-839972641327', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - Bilingual Welsh', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -519,8 +519,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1100, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.11', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1200, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.12', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;
@@ -611,5 +611,5 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('UR_EN_CRIS', 'CRIS UAC Replacement - English', '3543bcf5-6986-4d8d-80ab-79fba4d3f050', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', 'cfe91e5d-19a9-4325-8e4f-0bcbd1dcacff', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_UAC_EN_CRIS', 'CRIS Reminder with UAC - English', 'd0224400-4894-4bdd-b0bc-839972641327', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - bilingual', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
+('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - Bilingual Welsh', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -608,8 +608,8 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('NE_CY_CRIS', 'CRIS Notification - Bilingual Welsh', 'acd97184-b282-4ff9-98cf-ba14bf74c2f8', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_EN_CRIS', 'CRIS Reminder - English', '8cf30001-0c06-4da4-b49d-1df975a1123a', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_CY_CRIS', 'CRIS Reminder - Bilingual Welsh', '42af756c-7239-4486-b67d-ce2c6c4a7f9b', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_EN_CRIS', 'CRIS UAC Replacement - English', '3543bcf5-6986-4d8d-80ab-79fba4d3f050', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', 'cfe91e5d-19a9-4325-8e4f-0bcbd1dcacff', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
+('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
+('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
 ('RE_UAC_EN_CRIS', 'CRIS Reminder with UAC - English', 'd0224400-4894-4bdd-b0bc-839972641327', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - Bilingual Welsh', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1100, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.11', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1200, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.12', current_timestamp);

--- a/groundzero_ddl/packcode_templates/email_templates.sql
+++ b/groundzero_ddl/packcode_templates/email_templates.sql
@@ -3,8 +3,8 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('NE_CY_CRIS', 'CRIS Notification - Bilingual Welsh', 'acd97184-b282-4ff9-98cf-ba14bf74c2f8', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_EN_CRIS', 'CRIS Reminder - English', '8cf30001-0c06-4da4-b49d-1df975a1123a', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_CY_CRIS', 'CRIS Reminder - Bilingual Welsh', '42af756c-7239-4486-b67d-ce2c6c4a7f9b', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
-('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
+('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"]'),
+('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"]'),
 ('RE_UAC_EN_CRIS', 'CRIS Reminder with UAC - English', 'd0224400-4894-4bdd-b0bc-839972641327', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - Bilingual Welsh', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/groundzero_ddl/packcode_templates/email_templates.sql
+++ b/groundzero_ddl/packcode_templates/email_templates.sql
@@ -3,8 +3,8 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('NE_CY_CRIS', 'CRIS Notification - Bilingual Welsh', 'acd97184-b282-4ff9-98cf-ba14bf74c2f8', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_EN_CRIS', 'CRIS Reminder - English', '8cf30001-0c06-4da4-b49d-1df975a1123a', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_CY_CRIS', 'CRIS Reminder - Bilingual Welsh', '42af756c-7239-4486-b67d-ce2c6c4a7f9b', null ,'["PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_EN_CRIS', 'CRIS UAC Replacement - English', '3543bcf5-6986-4d8d-80ab-79fba4d3f050', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', 'cfe91e5d-19a9-4325-8e4f-0bcbd1dcacff', null ,'["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]'),
+('UR_EN_CRIS', 'CRIS UAC Replacement - English', '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
+('UR_CY_CRIS', 'CRIS UAC Replacement - Bilingual Welsh', '887accef-eac5-4842-b280-fe5f8af16c14', null ,'["__uac__","PORTAL_ID","FIRST_NAME"'),
 ('RE_UAC_EN_CRIS', 'CRIS Reminder with UAC - English', 'd0224400-4894-4bdd-b0bc-839972641327', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('RE_UAC_CY_CRIS', 'CRIS Reminder with UAC - Bilingual Welsh', 'bc35ebcd-63ca-4a90-aa4c-eea3e85ed506', null, '["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.0.11'
+CURRENT_VERSION = 'v1.0.12'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1200_update_uac_replacement_template.sql
+++ b/patches/1200_update_uac_replacement_template.sql
@@ -1,0 +1,14 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 1200
+-- Purpose: Update UAC reminder template ID
+-- Author: Kieran Wardle
+-- ****************************************************************************
+
+-- Replacement UAC Email Templates
+UPDATE casev3.email_template SET notify_template_id = '1b50c02e-ba9e-42d5-9f1a-aa6f6c28fe97' where pack_code = 'UR_EN_CRIS';
+UPDATE casev3.email_template SET notify_template_id = '887accef-eac5-4842-b280-fe5f8af16c14' where pack_code = 'UR_CY_CRIS';
+UPDATE casev3.email_template SET template = '["__uac__","PORTAL_ID","FIRST_NAME"]' where pack_code = 'UR_EN_CRIS';
+UPDATE casev3.email_template SET template = '["__uac__","PORTAL_ID","FIRST_NAME"]' where pack_code = 'UR_CY_CRIS';
+

--- a/patches/rollback/1200_update_uac_replacement_template.sql
+++ b/patches/rollback/1200_update_uac_replacement_template.sql
@@ -1,0 +1,13 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 1200
+-- Purpose: Rolback UAC reminder template ID
+-- Author: Kieran Wardle
+-- ****************************************************************************
+
+-- Replacement UAC Email Templates
+UPDATE casev3.email_template SET notify_template_id = '3543bcf5-6986-4d8d-80ab-79fba4d3f050' where pack_code = 'UR_EN_CRIS';
+UPDATE casev3.email_template SET notify_template_id = 'cfe91e5d-19a9-4325-8e4f-0bcbd1dcacff' where pack_code = 'UR_CY_CRIS';
+UPDATE casev3.email_template SET template = '["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]' where pack_code = 'UR_EN_CRIS';
+UPDATE casev3.email_template SET template = '["__uac__","PORTAL_ID","FIRST_NAME","__sensitive__.LAST_NAME"]' where pack_code = 'UR_CY_CRIS';


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ √] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: 1.0.12
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
We need to remove last name from our UAC replacement email templates


# What has changed
Added patch to update templates and notify template IDs

# How to test?
make dev-build
DB_PORT=6432 pipenv run python patch_database.py

Check rows in local DB  email_template table