### PR TITLE
Fix for dev postgres image

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -602,5 +602,5 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/groundzero_ddl/packcode_templates/email_templates.sql
+++ b/groundzero_ddl/packcode_templates/email_templates.sql
@@ -3,5 +3,5 @@ INSERT INTO casev3.email_template (pack_code, description, notify_template_id, m
 ('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
 ('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Dev postgres image is currently breaking in docker-dev. 

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Removed a rogue comma stopping the wcis inserts
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- Build the image and bring up docker-dev to see if it all works correctly
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Trello](https://trello.com/c/iEeFHhSc/)
