### PR TITLE
1043 Add Notify Service Ref Columns

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -521,8 +521,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.14', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.15', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;
@@ -601,8 +601,8 @@ COMMIT;
 -- Email Template
 -- WCIS EMAIL TEMPLATES
 INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template, notify_service_ref) VALUES
-('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service')
-ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);
+('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA')
+ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template, notify_service_ref) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template, EXCLUDED.notify_service_ref);

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -522,7 +522,7 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
 INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.15', current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.1.0', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -102,6 +102,7 @@ set schema 'casev3';
        pack_code varchar(255) not null,
         description varchar(255) not null,
         metadata jsonb,
+        notify_service_ref varchar(255) not null,
         notify_template_id uuid not null,
         template jsonb not null,
         primary key (pack_code)
@@ -230,6 +231,7 @@ set schema 'casev3';
        pack_code varchar(255) not null,
         description varchar(255) not null,
         metadata jsonb,
+        notify_service_ref varchar(255) not null,
         notify_template_id uuid not null,
         template jsonb not null,
         primary key (pack_code)
@@ -598,9 +600,9 @@ COMMIT;
 
 -- Email Template
 -- WCIS EMAIL TEMPLATES
-INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template) VALUES
-('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
+INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template, notify_service_ref) VALUES
+('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -83,6 +83,7 @@
        pack_code varchar(255) not null,
         description varchar(255) not null,
         metadata jsonb,
+        notify_service_ref varchar(255) not null,
         notify_template_id uuid not null,
         template jsonb not null,
         primary key (pack_code)
@@ -211,6 +212,7 @@
        pack_code varchar(255) not null,
         description varchar(255) not null,
         metadata jsonb,
+        notify_service_ref varchar(255) not null,
         notify_template_id uuid not null,
         template jsonb not null,
         primary key (pack_code)

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.14', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.15', current_timestamp);

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -5,4 +5,4 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
 INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.0.15', current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.1.0', current_timestamp);

--- a/groundzero_ddl/packcode_templates/email_templates.sql
+++ b/groundzero_ddl/packcode_templates/email_templates.sql
@@ -1,7 +1,7 @@
 -- WCIS EMAIL TEMPLATES
 INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template, notify_service_ref) VALUES
-('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service')
-ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);
+('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','Office_for_National_Statistics_surveys_UKHSA')
+ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template, notify_service_ref) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template, EXCLUDED.notify_service_ref);

--- a/groundzero_ddl/packcode_templates/email_templates.sql
+++ b/groundzero_ddl/packcode_templates/email_templates.sql
@@ -1,7 +1,7 @@
 -- WCIS EMAIL TEMPLATES
-INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template) VALUES
-('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]'),
-('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]')
+INSERT INTO casev3.email_template (pack_code, description, notify_template_id, metadata, template, notify_service_ref) VALUES
+('MNE_EN_WCIS', 'WCIS Main Notification Email - English', '6ff6a02f-f4ee-49ca-ba6c-4cabb1e72688', null ,'["__uac__","PORTAL_ID","COLLEX_OPEN_DATE","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('MRE_EN_WCIS', 'WCIS Main Reminder Email - English', '179b306c-ac35-4736-8804-94e8daaef511', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('FNE_EN_WCIS', 'WCIS Follow-up Notification Email - English', 'cdf7b57a-46d9-47cc-aea9-a6aaa3c153ba', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service'),
+('FRE_EN_WCIS', 'WCIS Follow-up Reminder Email - English', 'd66911c6-7323-4362-8eca-e5d2bee4d9f2', null ,'["__uac__","PORTAL_ID","COLLEX_CLOSE_DATE","FIRST_NAME","__sensitive__.LAST_NAME"]','wcis-service')
 ON CONFLICT (pack_code) DO UPDATE SET (description, notify_template_id, metadata, template) = (EXCLUDED.description, EXCLUDED.notify_template_id, EXCLUDED.metadata, EXCLUDED.template);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.0.15'
+CURRENT_VERSION = 'v1.1.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.0.14'
+CURRENT_VERSION = 'v1.0.15'
 
 
 def get_current_patch_number(db_cursor):
@@ -52,7 +52,6 @@ def patch_database(patches_directory, ddl_version_tag, db_cursor, db_connection)
         print(f'Successfully patched to version {ddl_version_tag}')
         return
     print(f'NO PATCHES TO APPLY AT VERSION: {ddl_version_tag}')
-
 
 def get_current_database_version_tag(db_cursor):
     db_cursor.execute('SELECT version_tag FROM ddl_version.version ORDER BY updated_timestamp DESC LIMIT 1')

--- a/patch_database.py
+++ b/patch_database.py
@@ -53,6 +53,7 @@ def patch_database(patches_directory, ddl_version_tag, db_cursor, db_connection)
         return
     print(f'NO PATCHES TO APPLY AT VERSION: {ddl_version_tag}')
 
+
 def get_current_database_version_tag(db_cursor):
     db_cursor.execute('SELECT version_tag FROM ddl_version.version ORDER BY updated_timestamp DESC LIMIT 1')
     return db_cursor.fetchone()[0]

--- a/patches/1500_add_notify_service_ref_column_and_seed_values.sql
+++ b/patches/1500_add_notify_service_ref_column_and_seed_values.sql
@@ -1,0 +1,13 @@
+-- ****************************************************************************
+-- RM SQL DATABASE INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 1500
+-- Purpose: Add Notify service ref columns to email and SMS templates, update existing rows
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.email_template ADD notify_service_ref VARCHAR(100);
+ALTER TABLE casev3.sms_template ADD notify_service_ref VARCHAR(100);
+
+UPDATE casev3.email_template SET notify_service_ref = 'Office_for_National_Statistics_surveys_UKHSA';
+UPDATE casev3.sms_template SET notify_service_ref = 'Office_for_National_Statistics_surveys_UKHSA';

--- a/patches/1500_add_notify_service_ref_column_and_seed_values.sql
+++ b/patches/1500_add_notify_service_ref_column_and_seed_values.sql
@@ -6,8 +6,8 @@
 -- Author: Adam Hawtin
 -- ****************************************************************************
 
-ALTER TABLE casev3.email_template ADD notify_service_ref VARCHAR(100);
-ALTER TABLE casev3.sms_template ADD notify_service_ref VARCHAR(100);
+ALTER TABLE casev3.email_template ADD notify_service_ref VARCHAR(255);
+ALTER TABLE casev3.sms_template ADD notify_service_ref VARCHAR(255);
 
 UPDATE casev3.email_template SET notify_service_ref = 'Office_for_National_Statistics_surveys_UKHSA';
 UPDATE casev3.sms_template SET notify_service_ref = 'Office_for_National_Statistics_surveys_UKHSA';

--- a/patches/1600_add_not_null_constraint_to_notify_service_ref.sql
+++ b/patches/1600_add_not_null_constraint_to_notify_service_ref.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 1600
+-- Purpose: Add NOT NULL constraint to notify_service_ref columns
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.email_template ALTER COLUMN notify_service_ref SET NOT NULL;
+ALTER TABLE casev3.sms_template ALTER COLUMN notify_service_ref SET NOT NULL;

--- a/patches/rollback/1500_add_notify_service_ref_column_and_seed_values.sql
+++ b/patches/rollback/1500_add_notify_service_ref_column_and_seed_values.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 1500
+-- Purpose: Rollback add Notify service ref columns to email and SMS templates
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.email_template DROP COLUMN notify_service_ref;
+ALTER TABLE casev3.sms_template DROP COLUMN notify_service_ref;

--- a/patches/rollback/1600_add_not_null_constraint_to_notify_service_ref.sql
+++ b/patches/rollback/1600_add_not_null_constraint_to_notify_service_ref.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 1600
+-- Purpose: Rollback add NOT NULL constraint to notify_service_ref columns
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.email_template ALTER COLUMN notify_service_ref DROP NOT NULL;
+ALTER TABLE casev3.sms_template ALTER COLUMN notify_service_ref DROP NOT NULL;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.17.0-SNAPSHOT</version>
+  <version>4.18.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/EmailTemplate.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/EmailTemplate.java
@@ -28,6 +28,9 @@ public class EmailTemplate {
   @Column(nullable = false)
   private String description;
 
+  @Column(nullable = false)
+  private String notifyServiceRef;
+
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
   private Object metadata;

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/SmsTemplate.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/SmsTemplate.java
@@ -28,6 +28,9 @@ public class SmsTemplate {
   @Column(nullable = false)
   private String description;
 
+  @Column(nullable = false)
+  private String notifyServiceRef;
+
   @Type(type = "jsonb")
   @Column(columnDefinition = "jsonb")
   private Object metadata;


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: `v1.1.0`
* [x] The POM has been updated with an appropriate version bump if required (4.18.0)

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support multiple Notify services, we need columns to store the reference for which Notify service each template belongs to.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add notify service ref columns to email and sms template objects and tables
- Add patch to add columns, with the current service ref
- Add patch to make column not null after updating all existing rows
- Add rollback patches
- Ran `make dev-build` to update the dev postgres SQL

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the SQL and patches

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
https://trello.com/c/gL7KBQtj/1043-govnotify-create-an-additional-service-13