### PR TITLE
SDCSRM-360 Add optional ATs support tool user set up

### DIFF
--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -48,7 +48,7 @@ pushd ../ui-permissions || exit 1
 psql "$PSQL_CONNECT_WRITE_MODE" -f RM-support-permissions.sql
 
 # Create the ATs UI user entry if an email is specified
-if [ -n $ACCEPTANCE_TESTS_EMAIL ]; then
+if [ -n "$ACCEPTANCE_TESTS_EMAIL" ]; then
   sed -e "s/\<ACCEPTANCE_TESTS_EMAIL>/$ACCEPTANCE_TESTS_EMAIL/" acceptance-tests-service-account.sql > tmp_acceptance-tests-service-account.sql
   psql "$PSQL_CONNECT_WRITE_MODE" -f tmp_acceptance-tests-service-account.sql
 fi

--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -49,7 +49,7 @@ psql "$PSQL_CONNECT_WRITE_MODE" -f RM-support-permissions.sql
 
 # Create the ATs UI user entry if an email is specified
 if [ -n "$ACCEPTANCE_TESTS_EMAIL" ]; then
-  sed -e "s/\<ACCEPTANCE_TESTS_EMAIL>/$ACCEPTANCE_TESTS_EMAIL/" acceptance-tests-service-account.sql > tmp_acceptance-tests-service-account.sql
+  sed -e "s/\$ACCEPTANCE_TESTS_EMAIL/$ACCEPTANCE_TESTS_EMAIL/" acceptance-tests-service-account.sql > tmp_acceptance-tests-service-account.sql
   psql "$PSQL_CONNECT_WRITE_MODE" -f tmp_acceptance-tests-service-account.sql
 fi
 

--- a/groundzero_ddl/rebuild_from_ground_zero.sh
+++ b/groundzero_ddl/rebuild_from_ground_zero.sh
@@ -46,5 +46,12 @@ psql "$PSQL_CONNECT_WRITE_MODE" -f packcode_templates/email_templates.sql
 # Create RM Support UI permissions
 pushd ../ui-permissions || exit 1
 psql "$PSQL_CONNECT_WRITE_MODE" -f RM-support-permissions.sql
+
+# Create the ATs UI user entry if an email is specified
+if [ -n $ACCEPTANCE_TESTS_EMAIL ]; then
+  sed -e "s/\<ACCEPTANCE_TESTS_EMAIL>/$ACCEPTANCE_TESTS_EMAIL/" acceptance-tests-service-account.sql > tmp_acceptance-tests-service-account.sql
+  psql "$PSQL_CONNECT_WRITE_MODE" -f tmp_acceptance-tests-service-account.sql
+fi
+
 popd || exit 1
 

--- a/ui-permissions/acceptance-tests-service-account.sql
+++ b/ui-permissions/acceptance-tests-service-account.sql
@@ -1,8 +1,8 @@
--- Add the ATs user row (note the placeholder email needs to be substituted)
+-- Add the ATs user row (note the placeholder "$ACCEPTANCE_TESTS_EMAIL" needs to be substituted in)
 -- Relies on RM-support-permissions.sql
 INSERT INTO casev3.users (id, email)
 VALUES ('7f51c6f0-bf65-454c-ae9f-6d59c47a0bb8', -- user ID
-        '<ACCEPTANCE_TESTS_EMAIL>');            -- AT user email
+        '$ACCEPTANCE_TESTS_EMAIL');             -- AT user email
 
 -- Add the ATs user ID to the super user group
 INSERT INTO casev3.user_group_member (id, group_id, user_id)

--- a/ui-permissions/acceptance-tests-service-account.sql
+++ b/ui-permissions/acceptance-tests-service-account.sql
@@ -1,0 +1,13 @@
+-- Add the ATs user row (note the placeholder email needs to be substituted)
+-- Relies on RM-support-permissions.sql
+INSERT INTO casev3.users (id, email)
+VALUES ('7f51c6f0-bf65-454c-ae9f-6d59c47a0bb8', -- user ID
+        '<ACCEPTANCE_TESTS_EMAIL>');            -- AT user email
+
+-- Add the ATs user ID to the super user group
+INSERT INTO casev3.user_group_member (id, group_id, user_id)
+VALUES ('8245edd0-956c-464b-a2bb-b44306d0b6b5',  -- member ID
+        '8269d75c-bfa1-4930-aca2-10dd9c6a2b42',  -- super user group ID
+        '7f51c6f0-bf65-454c-ae9f-6d59c47a0bb8'); -- user ID
+
+COMMIT;

--- a/ui-permissions/acceptance-tests-service-account.sql
+++ b/ui-permissions/acceptance-tests-service-account.sql
@@ -1,5 +1,6 @@
 -- Add the ATs user row (note the placeholder "$ACCEPTANCE_TESTS_EMAIL" needs to be substituted in)
 -- Relies on RM-support-permissions.sql
+BEGIN;
 INSERT INTO casev3.users (id, email)
 VALUES ('7f51c6f0-bf65-454c-ae9f-6d59c47a0bb8', -- user ID
         '$ACCEPTANCE_TESTS_EMAIL');             -- AT user email


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To allow the acceptance tests access to the support tool by IAP in dev environments, we need a user entry set up in the database.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add an optional AT user set up script to the UI permissions scripts

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the script

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-360