### PR TITLE
Dependabot ignore fix

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,9 @@ updates:
     labels:
       - "patch"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major" ]
 
   - package-ecosystem: "maven"
     directories:
@@ -30,3 +33,6 @@ updates:
     labels:
       - "patch"
       - "dependencies"
+    ignore:
+      - dependency-name: "*"
+        update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major" ]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,32 +1,32 @@
 version: 2
 updates:
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+      - "/"
+    target-branch: "main"
+    groups:
+      pip-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
+      interval: "daily"
     labels:
       - "patch"
       - "dependencies"
+
   - package-ecosystem: "maven"
-    directory: "/"
+    directories:
+      - "/"
+      - "/ssdc-rm-common-entity-model"
+    target-branch: "main"
+    groups:
+      maven-security-updates:
+        applies-to: "security-updates"
+        patterns:
+          - "*"
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
-    labels:
-      - "patch"
-      - "dependencies"
-  - package-ecosystem: "maven"
-    directory: "/ssdc-rm-common-entity-model"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
+      interval: "daily"
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
Ignore was missing on the dependabot config so we got PRs for all updates

# What has changed
Added in ignore field to ignore all updates

# How to test?
Check it looks ok