### PR TITLE
SDCSRM-520 Re-gen dev postgres init DDL

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -520,8 +520,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.2.1', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In #204 I forgot to re-run the dev postgres generation after updating the stored DDL version, so the dev-postgres is now out of date. This PR is just fixing that by committing the difference you now get if you re-generate the dev-postgres on main.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Re-generate dev postgres init

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the change matches the change created if you run `make dev-build` on main.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-520