### PR TITLE
SDCSRM-577 Make action rule status non-nullable

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -520,8 +520,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (500, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.1', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -20,7 +20,7 @@ set schema 'casev3';
 
     create table action_rule (
         id uuid not null,
-        action_rule_status varchar(255) check (action_rule_status in ('SCHEDULED','SELECTING_CASES','PROCESSING_CASES','COMPLETED','ERRORED')),
+        action_rule_status varchar(255) not null check (action_rule_status in ('SCHEDULED','SELECTING_CASES','PROCESSING_CASES','COMPLETED','ERRORED')),
         classifiers bytea,
         created_by varchar(255) not null,
         description varchar(50),

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -1,7 +1,7 @@
 
     create table action_rule (
         id uuid not null,
-        action_rule_status varchar(255) check (action_rule_status in ('SCHEDULED','SELECTING_CASES','PROCESSING_CASES','COMPLETED','ERRORED')),
+        action_rule_status varchar(255) not null check (action_rule_status in ('SCHEDULED','SELECTING_CASES','PROCESSING_CASES','COMPLETED','ERRORED')),
         classifiers bytea,
         created_by varchar(255) not null,
         description varchar(50),

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (500, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.1', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.3.0'
+CURRENT_VERSION = 'v1.3.1'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/500_set_action_rule_status_non_nullable.sql
+++ b/patches/500_set_action_rule_status_non_nullable.sql
@@ -1,0 +1,9 @@
+-- ****************************************************************************
+-- RM SQL DATABASE INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 500
+-- Purpose: Make the action rule action rule status column non-nullable
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.action_rule ALTER COLUMN action_rule_status SET NOT NULL;

--- a/patches/rollback/500_set_action_rule_status_non_nullable.sql
+++ b/patches/rollback/500_set_action_rule_status_non_nullable.sql
@@ -1,0 +1,9 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 500
+-- Purpose: Rollback setting action rule status non-nullable
+-- Author: Adam Hawtin
+-- ****************************************************************************
+
+ALTER TABLE casev3.action_rule ALTER COLUMN action_rule_status DROP NOT NULL;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.22.0-SNAPSHOT</version>
+  <version>4.22.1-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ActionRule.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ActionRule.java
@@ -26,7 +26,7 @@ public class ActionRule {
   @Id private UUID id;
 
   @Enumerated(EnumType.STRING)
-  @Column(nullable = true) // TODO should be non nullable, this is for the first stage of migration
+  @Column(nullable = false)
   private ActionRuleStatus actionRuleStatus;
 
   @Enumerated(EnumType.STRING)


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [x] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
#204 Added an action rule status column, which is intended to be non-null, this PR completes the second stage of migration to enforce the not null constraint on the column.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Make action rule status non-nullable

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Check the change, run the ATs locally and ensure creating an action rule through the support tool or wave generator script still work as expected

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-577