### PR TITLE
Added docker login step to Megalinter github action

### DIFF
--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,6 +36,13 @@ jobs:
         with:
           token: ${{ secrets.PAT || secrets.GITHUB_TOKEN }}
 
+      # Authenticating with Dockerhub ensures image pulls are authenticated, so not as severely rate limited
+      - name: Log in to Dockerhub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       # MegaLinter
       - name: MegaLinter
 


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
Our Megalinter GitHub action is currently not using our docker credentials, causing us to hit their rate limiting and fail jobs

# What has changed
Added login step to megaliter GitHub action