### PR TITLE
Sdcsrm 982 update rm app user permissions on tables

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -520,8 +520,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.2', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.3', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.2', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.3', current_timestamp);

--- a/groundzero_ddl/roles/rm_app_user.sql
+++ b/groundzero_ddl/roles/rm_app_user.sql
@@ -12,14 +12,14 @@ GRANT USAGE ON SCHEMA exceptionmanager TO rm_app_user;
 GRANT USAGE ON SCHEMA uacqid TO rm_app_user;
 
 -- casev3 table permissions
-GRANT SELECT, INSERT, UPDATE ON casev3.action_rule TO rm_app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.action_rule TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.action_rule_survey_email_template TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.action_rule_survey_export_file_template TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.action_rule_survey_sms_template TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.cases TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.case_to_process TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.cluster_leader TO rm_app_user;
-GRANT SELECT, INSERT ON casev3.collection_exercise TO rm_app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.collection_exercise TO rm_app_user;
 GRANT SELECT, INSERT ON casev3.email_template TO rm_app_user;
 GRANT SELECT, INSERT  ON casev3.event TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.export_file_row TO rm_app_user;
@@ -33,7 +33,7 @@ GRANT SELECT, INSERT, UPDATE ON casev3.job TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.job_row TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.message_to_send TO rm_app_user;
 GRANT SELECT, INSERT ON casev3.sms_template TO rm_app_user;
-GRANT SELECT, INSERT ON casev3.survey TO rm_app_user;
+GRANT SELECT, INSERT, UPDATE, DELETE ON casev3.survey TO rm_app_user;
 GRANT SELECT, INSERT, UPDATE ON casev3.uac_qid_link TO rm_app_user;
 GRANT SELECT, INSERT ON casev3.users TO rm_app_user;
 GRANT SELECT, INSERT ON casev3.user_group TO rm_app_user;

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.3.2'
+CURRENT_VERSION = 'v1.3.3'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/700_grant_rm_app_user_update_and_delete_permissions.sql
+++ b/patches/700_grant_rm_app_user_update_and_delete_permissions.sql
@@ -1,0 +1,11 @@
+-- ****************************************************************************
+-- RM SQL DATABASE INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 700
+-- Purpose: Grant update and delete permissions to rm app user
+-- Author: Ryan Grundy
+-- ****************************************************************************
+
+GRANT UPDATE, DELETE ON casev3.collection_exercise TO rm_app_user;
+GRANT UPDATE, DELETE ON casev3.survey TO rm_app_user;
+GRANT DELETE ON casev3.action_rule TO rm_app_user;

--- a/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
+++ b/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
@@ -6,6 +6,6 @@
 -- Author: Ryan Grundy
 -- ****************************************************************************
 
-REVOKE UPDATE ON casev3.collection_exercise TO rm_app_user;
-REVOKE UPDATE ON casev3.survey TO rm_app_user;
-REVOKE DELETE ON casev3.action_rule TO rm_app_user;
+REVOKE UPDATE ON casev3.collection_exercise FROM rm_app_user;
+REVOKE UPDATE ON casev3.survey FROM rm_app_user;
+REVOKE DELETE ON casev3.action_rule FROM rm_app_user;

--- a/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
+++ b/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
@@ -6,6 +6,6 @@
 -- Author: Ryan Grundy
 -- ****************************************************************************
 
-REVOKE UPDATE ON casev3.collection_exercise FROM rm_app_user;
-REVOKE UPDATE ON casev3.survey FROM rm_app_user;
+REVOKE UPDATE, DELETE ON casev3.collection_exercise FROM rm_app_user;
+REVOKE UPDATE, DELETE ON casev3.survey FROM rm_app_user;
 REVOKE DELETE ON casev3.action_rule FROM rm_app_user;

--- a/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
+++ b/patches/rollback/700_grant_rm_app_user_update_and_delete_permissions.sql
@@ -1,0 +1,11 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 700
+-- Purpose: Rollback grant update and delete permissions to rm app user
+-- Author: Ryan Grundy
+-- ****************************************************************************
+
+REVOKE UPDATE ON casev3.collection_exercise TO rm_app_user;
+REVOKE UPDATE ON casev3.survey TO rm_app_user;
+REVOKE DELETE ON casev3.action_rule TO rm_app_user;


### PR DESCRIPTION
**Review this PR first: https://github.com/ONSdigital/ssdc-rm-ddl/pull/223** 

# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
For the support-frontend, we're allowing the user to update and delete survey, collection exercises and action rules. To allow this to work in GCP. We need to update the app user permissions.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Added patch script to grant further permissions to the app user
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
- In GCP, test the support frontend and when you try an edit a survey or delete an action rule, you should see an error.
- Run the patch database script, try editing a survey, and delete an action rule; it should work as expected.
- Try running the ground zero script as well to make sure it all works expected from that point as well
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-982)
