### PR TITLE
Add new sample_validation_name column to casev3.survey table

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -247,6 +247,7 @@ set schema 'casev3';
         name varchar(255) not null,
         sample_definition_url varchar(255) not null,
         sample_separator char(1) not null,
+        sample_validation_name varchar(25),
         sample_validation_rules jsonb not null,
         sample_with_header_row boolean not null,
         primary key (id)
@@ -309,6 +310,9 @@ set schema 'casev3';
 
     create index qid_idx 
        on uac_qid_link (qid);
+
+    create index uac_qid_caseid_idx 
+       on uac_qid_link (caze_id);
 
     alter table if exists action_rule 
        add constraint FK6twtf1ksysh99e4g2ejmoy6c1 
@@ -521,8 +525,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (800, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.4', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (900, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.5', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -227,6 +227,7 @@
         name varchar(255) not null,
         sample_definition_url varchar(255) not null,
         sample_separator char(1) not null,
+        sample_validation_name varchar(25),
         sample_validation_rules jsonb not null,
         sample_with_header_row boolean not null,
         primary key (id)

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (800, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.4', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (900, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.5', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.3.4'
+CURRENT_VERSION = 'v1.3.5'
 
 
 def get_current_patch_number(db_cursor):

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.22.3-SNAPSHOT</version>
+  <version>4.22.4-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/Survey.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/Survey.java
@@ -40,6 +40,9 @@ public class Survey {
   @Column(nullable = false, length = 1)
   private char sampleSeparator;
 
+  @Column(nullable = true, length = 25)
+  private String sampleValidationName;
+
   @OneToMany(mappedBy = "survey")
   private List<CollectionExercise> collectionExercises;
 


### PR DESCRIPTION
# Has the DDL schema changed?
Yes

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: 4.22.4
* [x] The POM has been updated with an appropriate version bump if required

# Motivation and Context
We need a new column so that we can store the name of the sample validation template name


# What has changed
New `sample_validation_name` column to be added to the survey table.  The column is nullable so any existing functionality shouldn't be affected.

# How to test?
Check everything builds and still runs as expected.  Future work will post data to this new column.

# Links
[SDCSRM-1071](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1071)

