### PR TITLE
Add index on event table on uac_qid_link_id_column

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -312,6 +312,9 @@ set schema 'casev3';
     create index case_idx 
        on event (caze_id);
 
+    create index event_uac_qid_link_id_idx 
+       on event (uac_qid_link_id);
+
     create index qid_idx 
        on uac_qid_link (qid);
 
@@ -529,8 +532,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1200, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.8', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1300, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.9', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -292,6 +292,9 @@
     create index case_idx 
        on event (caze_id);
 
+    create index event_uac_qid_link_id_idx 
+       on event (uac_qid_link_id);
+
     create index qid_idx 
        on uac_qid_link (qid);
 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1200, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.8', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1300, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.9', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.3.8'
+CURRENT_VERSION = 'v1.3.9'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1300_add_uac_qid_link_id_index_to_event.sql
+++ b/patches/1300_add_uac_qid_link_id_index_to_event.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 1300
+-- Purpose: Add an index on the uac_qid_link_id column to the casev3.event table
+-- Author: Gavin Edwards
+-- ****************************************************************************
+
+
+CREATE INDEX IF NOT EXISTS event_uac_qid_link_id_idx ON casev3.event (uac_qid_link_id);

--- a/patches/rollback/1300_add_uac_qid_link_id_index_to_event.sql
+++ b/patches/rollback/1300_add_uac_qid_link_id_index_to_event.sql
@@ -1,0 +1,10 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 1300
+-- Purpose: Rollback adding an index on the uac_qid_link_id column to the casev3.event table
+-- Author: Gavin Edwards
+-- ****************************************************************************
+
+
+DROP INDEX IF EXISTS event_uac_qid_link_id_idx;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.23.1-SNAPSHOT</version>
+  <version>4.23.2-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/Event.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/Event.java
@@ -24,7 +24,10 @@ import org.hibernate.annotations.Type;
 @DynamicUpdate
 @Table(
     name = "event",
-    indexes = {@Index(name = "case_idx", columnList = "caze_id")})
+    indexes = {
+      @Index(name = "case_idx", columnList = "caze_id"),
+      @Index(name = "event_uac_qid_link_id_idx", columnList = "uac_qid_link_id")
+    })
 public class Event {
   @Id private UUID id;
 


### PR DESCRIPTION
# Has the DDL schema changed?
Yes

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [x] The POM has been updated with an appropriate version bump if required

# Motivation and Context
The event table in production currently contains 18.6m rows but has no index on it.  When attempting to view case details in support tool, the case is joined with event and for each join, it does a full table scan, takes ages then crashes. Adding an index to the event table should speed up the query and prevent future crashes.

# What has changed
New index on event table.  One was added as part of https://github.com/ONSdigital/ssdc-rm-ddl/pull/232 but another is needed.

# How to test?
Unless you want to attempt spinning up an env and using an event table with 18m rows then it'll be hard to test at scale.  Adding an index can only make it better. 

Build this, then job processor, case processor, notify service and support-tool (due the the common entity model being updated).

# Links
[SDCSRM-1480](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1480)
