### PR TITLE
Create MI snapshot tables for response rates, email requests and export file requests

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -231,6 +231,42 @@ set schema 'casev3';
         primary key (id)
     );
 
+    create table mi_email_request (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        daily_email_requests integer not null,
+        pack_code varchar(255) not null,
+        snapshot_date date not null,
+        total_email_requests integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_email_request unique (collection_exercise_id, pack_code, snapshot_date)
+    );
+
+    create table mi_export_file_request (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        daily_export_file_requests integer not null,
+        pack_code varchar(255) not null,
+        snapshot_date date not null,
+        total_export_file_requests integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_export_file_request unique (collection_exercise_id, pack_code, snapshot_date)
+    );
+
+    create table mi_response_rate (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        launched_count integer not null,
+        receipted_count integer not null,
+        snapshot_date date not null,
+        total_case_count integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_response_rate unique (collection_exercise_id, snapshot_date)
+    );
+
     create table sms_template (
         pack_code varchar(255) not null,
         description varchar(255) not null,
@@ -451,6 +487,21 @@ set schema 'casev3';
        foreign key (job_id) 
        references job;
 
+    alter table if exists mi_email_request 
+       add constraint FKsxiygxf780dbpd8pri18f9s17 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
+
+    alter table if exists mi_export_file_request 
+       add constraint FKmxeys20naitne09r6pnh40vqx 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
+
+    alter table if exists mi_response_rate 
+       add constraint FKpwdd5j7bbj9dl1ow02nwlw8hw 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
+
     alter table if exists uac_qid_link 
        add constraint FKngo7bm72f0focdujjma78t4nk 
        foreign key (caze_id) 
@@ -532,8 +583,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.9', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -211,6 +211,42 @@
         primary key (id)
     );
 
+    create table mi_email_request (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        daily_email_requests integer not null,
+        pack_code varchar(255) not null,
+        snapshot_date date not null,
+        total_email_requests integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_email_request unique (collection_exercise_id, pack_code, snapshot_date)
+    );
+
+    create table mi_export_file_request (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        daily_export_file_requests integer not null,
+        pack_code varchar(255) not null,
+        snapshot_date date not null,
+        total_export_file_requests integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_export_file_request unique (collection_exercise_id, pack_code, snapshot_date)
+    );
+
+    create table mi_response_rate (
+        id bigserial not null,
+        created_at timestamp with time zone not null,
+        launched_count integer not null,
+        receipted_count integer not null,
+        snapshot_date date not null,
+        total_case_count integer not null,
+        collection_exercise_id uuid not null,
+        primary key (id),
+        constraint uq_mi_response_rate unique (collection_exercise_id, snapshot_date)
+    );
+
     create table sms_template (
         pack_code varchar(255) not null,
         description varchar(255) not null,
@@ -430,6 +466,21 @@
        add constraint FK8motlil4mayre4vvdipnjime0 
        foreign key (job_id) 
        references job;
+
+    alter table if exists mi_email_request 
+       add constraint FKsxiygxf780dbpd8pri18f9s17 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
+
+    alter table if exists mi_export_file_request 
+       add constraint FKmxeys20naitne09r6pnh40vqx 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
+
+    alter table if exists mi_response_rate 
+       add constraint FKpwdd5j7bbj9dl1ow02nwlw8hw 
+       foreign key (collection_exercise_id) 
+       references collection_exercise;
 
     alter table if exists uac_qid_link 
        add constraint FKngo7bm72f0focdujjma78t4nk 

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1300, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.3.9', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.3.9'
+CURRENT_VERSION = 'v1.4.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1400_create_mi_tables.sql
+++ b/patches/1400_create_mi_tables.sql
@@ -1,0 +1,48 @@
+-- ****************************************************************************
+-- RM SQL DATABASE UPDATE SCRIPT
+-- ****************************************************************************
+-- Number: 1400
+-- Purpose: Create MI snapshot tables for response rates, email requests and
+--          export file requests
+-- Author: Prem Buczkowski
+-- ****************************************************************************
+
+
+CREATE TABLE casev3.mi_response_rate (
+    id bigserial NOT NULL,
+    collection_exercise_id uuid NOT NULL,
+    snapshot_date date NOT NULL,
+    receipted_count integer NOT NULL,
+    launched_count integer NOT NULL,
+    total_case_count integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_mi_response_rate UNIQUE (collection_exercise_id, snapshot_date),
+    CONSTRAINT fk_mi_response_rate_collex FOREIGN KEY (collection_exercise_id) REFERENCES casev3.collection_exercise (id)
+);
+
+CREATE TABLE casev3.mi_email_request (
+    id bigserial NOT NULL,
+    collection_exercise_id uuid NOT NULL,
+    pack_code varchar(255) NOT NULL,
+    snapshot_date date NOT NULL,
+    daily_email_requests integer NOT NULL,
+    total_email_requests integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_mi_email_request UNIQUE (collection_exercise_id, pack_code, snapshot_date),
+    CONSTRAINT fk_mi_email_request_collex FOREIGN KEY (collection_exercise_id) REFERENCES casev3.collection_exercise (id)
+);
+
+CREATE TABLE casev3.mi_export_file_request (
+    id bigserial NOT NULL,
+    collection_exercise_id uuid NOT NULL,
+    pack_code varchar(255) NOT NULL,
+    snapshot_date date NOT NULL,
+    daily_export_file_requests integer NOT NULL,
+    total_export_file_requests integer NOT NULL,
+    created_at timestamp with time zone NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT uq_mi_export_file_request UNIQUE (collection_exercise_id, pack_code, snapshot_date),
+    CONSTRAINT fk_mi_export_file_request_collex FOREIGN KEY (collection_exercise_id) REFERENCES casev3.collection_exercise (id)
+);

--- a/patches/rollback/1400_create_mi_tables.sql
+++ b/patches/rollback/1400_create_mi_tables.sql
@@ -1,0 +1,12 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 1400
+-- Purpose: Rollback creation of MI snapshot tables
+-- Author: Prem Buczkowski
+-- ****************************************************************************
+
+
+DROP TABLE IF EXISTS casev3.mi_export_file_request;
+DROP TABLE IF EXISTS casev3.mi_email_request;
+DROP TABLE IF EXISTS casev3.mi_response_rate;

--- a/src/main/java/uk/gov/ons/ssdc/rm/ddl/Application.java
+++ b/src/main/java/uk/gov/ons/ssdc/rm/ddl/Application.java
@@ -29,10 +29,11 @@ public class Application {
 
   private static void generate(Class dialect, String schemaName, String... packagesName) {
 
-    MetadataSources metadata = new MetadataSources(
-        new StandardServiceRegistryBuilder()
-            .applySetting("hibernate.dialect", dialect.getName())
-            .build());
+    MetadataSources metadata =
+        new MetadataSources(
+            new StandardServiceRegistryBuilder()
+                .applySetting("hibernate.dialect", dialect.getName())
+                .build());
 
     for (String packageName : packagesName) {
       System.out.println("packageName: " + packageName);
@@ -50,7 +51,7 @@ public class Application {
     export.setOutputFile(filename);
     export.setFormat(true);
 
-    //can change the output here
+    // can change the output here
     EnumSet<TargetType> enumSet = EnumSet.of(TargetType.SCRIPT);
     export.execute(enumSet, SchemaExport.Action.CREATE, metadataImplementor);
   }
@@ -58,9 +59,8 @@ public class Application {
   public static final List<Class<?>> getClasses(String packageName) {
     String path = packageName.replaceAll("\\.", File.separator);
     List<Class<?>> classes = new ArrayList<>();
-    String[] classPathEntries = System.getProperty("java.class.path").split(
-        System.getProperty("path.separator")
-    );
+    String[] classPathEntries =
+        System.getProperty("java.class.path").split(System.getProperty("path.separator"));
 
     String name;
     for (String classpathEntry : classPathEntries) {

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.23.2-SNAPSHOT</version>
+  <version>4.24.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiEmailRequest.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiEmailRequest.java
@@ -1,0 +1,45 @@
+package uk.gov.ons.ssdc.common.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_mi_email_request",
+            columnNames = {"collection_exercise_id", "pack_code", "snapshot_date"}))
+public class MiEmailRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @ManyToOne(optional = false)
+  private CollectionExercise collectionExercise;
+
+  // Not a FK to EmailTemplate - MI rows are historical snapshots and must survive template deletion
+  @Column(nullable = false)
+  private String packCode;
+
+  @Column(nullable = false)
+  private LocalDate snapshotDate;
+
+  @Column(nullable = false)
+  private int dailyEmailRequests;
+
+  @Column(nullable = false)
+  private int totalEmailRequests;
+
+  @Column(nullable = false, columnDefinition = "timestamp with time zone")
+  private OffsetDateTime createdAt;
+}

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiExportFileRequest.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiExportFileRequest.java
@@ -1,0 +1,45 @@
+package uk.gov.ons.ssdc.common.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_mi_export_file_request",
+            columnNames = {"collection_exercise_id", "pack_code", "snapshot_date"}))
+public class MiExportFileRequest {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @ManyToOne(optional = false)
+  private CollectionExercise collectionExercise;
+
+  // Not a FK to ExportFileTemplate - MI rows are historical snapshots and must survive template deletion
+  @Column(nullable = false)
+  private String packCode;
+
+  @Column(nullable = false)
+  private LocalDate snapshotDate;
+
+  @Column(nullable = false)
+  private int dailyExportFileRequests;
+
+  @Column(nullable = false)
+  private int totalExportFileRequests;
+
+  @Column(nullable = false, columnDefinition = "timestamp with time zone")
+  private OffsetDateTime createdAt;
+}

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiExportFileRequest.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiExportFileRequest.java
@@ -27,7 +27,8 @@ public class MiExportFileRequest {
   @ManyToOne(optional = false)
   private CollectionExercise collectionExercise;
 
-  // Not a FK to ExportFileTemplate - MI rows are historical snapshots and must survive template deletion
+  // Not a FK to ExportFileTemplate - MI rows are historical snapshots and must survive template
+  // deletion
   @Column(nullable = false)
   private String packCode;
 

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiResponseRate.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/MiResponseRate.java
@@ -1,0 +1,44 @@
+package uk.gov.ons.ssdc.common.model.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_mi_response_rate",
+            columnNames = {"collection_exercise_id", "snapshot_date"}))
+public class MiResponseRate {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private long id;
+
+  @ManyToOne(optional = false)
+  private CollectionExercise collectionExercise;
+
+  @Column(nullable = false)
+  private LocalDate snapshotDate;
+
+  @Column(nullable = false)
+  private int receiptedCount;
+
+  @Column(nullable = false)
+  private int launchedCount;
+
+  @Column(nullable = false)
+  private int totalCaseCount;
+
+  @Column(nullable = false, columnDefinition = "timestamp with time zone")
+  private OffsetDateTime createdAt;
+}


### PR DESCRIPTION
# Has the DDL schema changed?
* [X] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: v1.4.0
* [X] The POM has been updated with an appropriate version bump if required

# Motivation and Context
This commit adds tables to store MI data, which is already exported daily to a bucket in GCS, to the database as well. This will allow SRM self-serve tool to easily fetch it.

The motivation is further detailed here: https://officefornationalstatistics.atlassian.net/wiki/spaces/SDC/pages/250773536/MI+Dashboard+Analysis

A script to load historical data from CSV files will follow.

# What has changed
* Three tables added: mi_email_request, mi_export_file_request, mi_response_rate
* The entity model and SQL files regenerated
* Patch and rollback added

# How to test?
Apply the patch and check if the tables were created.

# Links
Jira: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1512
Confluence (design and motivation): https://officefornationalstatistics.atlassian.net/wiki/spaces/SDC/pages/250773536/MI+Dashboard+Analysis
