### PR TITLE
Grant access to MI tables to the RM app user

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -583,8 +583,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1500, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.1', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1400, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1500, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.4.1', current_timestamp);

--- a/groundzero_ddl/roles/rm_app_user.sql
+++ b/groundzero_ddl/roles/rm_app_user.sql
@@ -40,6 +40,9 @@ GRANT SELECT, INSERT ON casev3.user_group TO rm_app_user;
 GRANT SELECT, INSERT, DELETE ON casev3.user_group_admin TO rm_app_user;
 GRANT SELECT, INSERT, DELETE ON casev3.user_group_member TO rm_app_user;
 GRANT SELECT, INSERT, DELETE ON casev3.user_group_permission TO rm_app_user;
+GRANT SELECT, INSERT ON casev3.mi_response_rate TO rm_app_user;
+GRANT SELECT, INSERT ON casev3.mi_email_request TO rm_app_user;
+GRANT SELECT, INSERT ON casev3.mi_export_file_request TO rm_app_user;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON exceptionmanager.quarantined_message TO rm_app_user;
 GRANT SELECT, UPDATE, INSERT, DELETE ON exceptionmanager.auto_quarantine_rule TO rm_app_user;

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.4.0'
+CURRENT_VERSION = 'v1.4.1'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1500_grant_rm_app_user_mi_table_permissions.sql
+++ b/patches/1500_grant_rm_app_user_mi_table_permissions.sql
@@ -1,0 +1,15 @@
+-- ****************************************************************************
+-- RM SQL DATABASE INSERT SCRIPT
+-- ****************************************************************************
+-- Number: 1500
+-- Purpose: Grant rm_app_user permissions for MI snapshot tables and sequences
+-- Author: Prem Buczkowski
+-- ****************************************************************************
+
+GRANT SELECT, INSERT ON casev3.mi_response_rate TO rm_app_user;
+GRANT SELECT, INSERT ON casev3.mi_email_request TO rm_app_user;
+GRANT SELECT, INSERT ON casev3.mi_export_file_request TO rm_app_user;
+
+GRANT SELECT, UPDATE ON SEQUENCE casev3.mi_response_rate_id_seq TO rm_app_user;
+GRANT SELECT, UPDATE ON SEQUENCE casev3.mi_email_request_id_seq TO rm_app_user;
+GRANT SELECT, UPDATE ON SEQUENCE casev3.mi_export_file_request_id_seq TO rm_app_user;

--- a/patches/rollback/1500_grant_rm_app_user_mi_table_permissions.sql
+++ b/patches/rollback/1500_grant_rm_app_user_mi_table_permissions.sql
@@ -1,0 +1,15 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK SCRIPT
+-- ****************************************************************************
+-- Number: 1500
+-- Purpose: Revoke rm_app_user permissions from MI snapshot tables and sequences
+-- Author: Prem Buczkowski
+-- ****************************************************************************
+
+REVOKE SELECT, INSERT ON casev3.mi_response_rate FROM rm_app_user;
+REVOKE SELECT, INSERT ON casev3.mi_email_request FROM rm_app_user;
+REVOKE SELECT, INSERT ON casev3.mi_export_file_request FROM rm_app_user;
+
+REVOKE SELECT, UPDATE ON SEQUENCE casev3.mi_response_rate_id_seq FROM rm_app_user;
+REVOKE SELECT, UPDATE ON SEQUENCE casev3.mi_email_request_id_seq FROM rm_app_user;
+REVOKE SELECT, UPDATE ON SEQUENCE casev3.mi_export_file_request_id_seq FROM rm_app_user;


### PR DESCRIPTION
# Has the DDL schema changed?
This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
version: v1.4.1

The POM has not been updated, as it's not required for this change.

# Motivation and Context
As requested in https://github.com/ONSdigital/srm-monitoring/pull/41#issuecomment-4314074529 so the RM apps can access and insert into the new table (but not delete).

# What has changed
Granted SELECT and DELETE to rm_app_user on the new MI tables, and sequences necessary for insertion.

# How to test?
Switch to rm_app_user and check if you can access the new tables.

# Links
Jira: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1512
Monitoring PR: https://github.com/ONSdigital/srm-monitoring/pull/41
MI DDL PR: https://github.com/ONSdigital/ssdc-rm-ddl/pull/236
