### PR TITLE
Sdcsrm 1485 corp mac changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ nb-configuration.xml
 
 # Megalinter reports
 megalinter-reports/
+
+# Podman secrets
+podman-build-secret*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER ?= $(shell if [ "$$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 install:
 	pipenv install --dev
 
@@ -8,7 +11,7 @@ test: lint
 	pipenv run pytest ./test --cov --cov-report term-missing --cov-report xml
 
 build-ddl-docker:
-	docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-ddl:latest
+	$(DOCKER) build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-ddl:latest
 
 check-ddl:
 	mvn pmd:check
@@ -31,13 +34,13 @@ shellcheck:
 	shellcheck -x --shell=bash **/*.sh *.sh
 
 pull-latest-dev-postgres:
-	docker pull europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
+	$(DOCKER) pull europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
 
 dev-postgres-up:
-	docker compose -f docker-compose-dev-postgres.yml up -d
+	$(DOCKER) compose -f docker-compose-dev-postgres.yml up -d
 
 dev-postgres-down:
-	docker compose -f docker-compose-dev-postgres.yml down
+	$(DOCKER) compose -f docker-compose-dev-postgres.yml down
 
 run-test-patches:
 	DB_PORT=16432 pipenv run python patch_database.py
@@ -51,18 +54,18 @@ wait-for-docker-postgres:
 test-patches: pull-latest-dev-postgres dev-postgres-down dev-postgres-up wait-for-docker-postgres run-test-patches run-test-rollback dev-postgres-down
 
 build-dev-postgres-image:
-	docker build ./dev-common-postgres-image -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
+	$(DOCKER) build ./dev-common-postgres-image --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
 
 test-dev-postgres: build-dev-postgres-image dev-postgres-up wait-for-docker-postgres dev-postgres-down
 
 megalint:  ## Run the mega-linter.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		oxsecurity/megalinter:v8
 
 megalint-fix:  ## Run the mega-linter and attempt to auto fix any issues.
-	docker run --platform linux/amd64 --rm \
+	$(DOCKER) run --platform linux/amd64 --rm \
 		-v /var/run/docker.sock:/var/run/docker.sock:rw \
 		-v $(shell pwd):/tmp/lint:rw \
 		-e APPLY_FIXES=all \

--- a/README.md
+++ b/README.md
@@ -36,6 +36,14 @@ in the [pom.xml](ssdc-rm-common-entity-model/pom.xml) file.
 
 ## Building the DDL
 
+Podman and Docker are both supported for building and running the application.
+By default the Makefile will use `docker` unless you are on an `arm64` architecture (e.g. M1/M2 Mac) in which case it will use `podman`.
+You can override this by setting the `DOCKER` environment variable to either `docker` or `podman`.
+For example, to force using `docker` on an M1/M2 Mac:
+```shell
+DOCKER=docker make <command>
+```
+
 To regenerate the DDL and build everything you need locally, run:
 
 ```shell

--- a/build_groundzero_ddl.sh
+++ b/build_groundzero_ddl.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER=$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 set -e
 rm groundzero_ddl/casev3.sql
 rm groundzero_ddl/uacqid.sql
@@ -57,5 +61,5 @@ java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar exceptionmanager uk.gov.ons.ssdc.e
 ./build_init_script.sh
 
 pushd dev-common-postgres-image || exit 1
-docker build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
+$DOCKER build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
 popd || exit 1

--- a/build_groundzero_ddl.sh
+++ b/build_groundzero_ddl.sh
@@ -61,5 +61,5 @@ java -jar target/ssdc-rm-ddl-1.0-SNAPSHOT.jar exceptionmanager uk.gov.ons.ssdc.e
 ./build_init_script.sh
 
 pushd dev-common-postgres-image || exit 1
-$DOCKER build . -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
+$DOCKER build . --platform linux/amd64 -t europe-west2-docker.pkg.dev/ssdc-rm-ci/docker/ssdc-rm-dev-common-postgres:latest
 popd || exit 1

--- a/wait_for_docker_postgres.sh
+++ b/wait_for_docker_postgres.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
+# Set the container runtime based on architecture, default to docker for amd64 and podman for arm64
+DOCKER=$(if [ "$(uname -m)" = "arm64" ]; then echo podman; else echo docker; fi)
+
 POSTGRES_CONTAINER=dev-postgres-ddl
+
 echo "Waiting for [$POSTGRES_CONTAINER] to be ready"
 
 while true; do
-  response=$(docker inspect $POSTGRES_CONTAINER -f "{{ .State.Health.Status }}")
+  response=$($DOCKER inspect $POSTGRES_CONTAINER -f "{{ .State.Health.Status }}")
   if [[ "$response" == "healthy" ]]; then
     echo "[$POSTGRES_CONTAINER] is ready"
     break


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
Updates to allow devs to run all `make` commands on both new and old Macbooks.


# What has changed
- Updated the make commands to use `docker` or `podman` depending on Mac architecture.
- Updated  any shell scripts that build docker images to do the same - I've updated the scrips themselves to check the architecture rather than passing it through from the makefile so that they can be run independently of a makefile 
- Updated gitignore and readme

Common entity model doesn't run integration tests with docker-compose like other repos, so no change is needed to the pom/codebase.  This means no version bumps everywhere.

# How to test?
- Run every make command.  Everything should work on both new and old macs as expected.

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1485
