### PR TITLE
Made fields non null in action template row

### DIFF
--- a/dev-common-postgres-image/init.sql
+++ b/dev-common-postgres-image/init.sql
@@ -71,9 +71,9 @@ set schema 'casev3';
     create table action_template_row (
         id uuid not null,
         action_type varchar(255) not null check (action_type in ('EXPORT_FILE','OUTBOUND_TELEPHONE','FACE_TO_FACE','DEACTIVATE_UAC','SMS','EMAIL','EQ_FLUSH')),
-        cohort integer,
-        day_offset integer,
-        trigger_time time(6),
+        cohort integer not null,
+        day_offset integer not null,
+        trigger_time time(6) not null,
         action_template_id uuid not null,
         email_template_pack_code varchar(255),
         primary key (id)
@@ -623,8 +623,8 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.5.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.6.0', current_timestamp);
 
 -- Seed Support Tool UI permissions
 BEGIN;

--- a/groundzero_ddl/casev3.sql
+++ b/groundzero_ddl/casev3.sql
@@ -51,9 +51,9 @@
     create table action_template_row (
         id uuid not null,
         action_type varchar(255) not null check (action_type in ('EXPORT_FILE','OUTBOUND_TELEPHONE','FACE_TO_FACE','DEACTIVATE_UAC','SMS','EMAIL','EQ_FLUSH')),
-        cohort integer,
-        day_offset integer,
-        trigger_time time(6),
+        cohort integer not null,
+        day_offset integer not null,
+        trigger_time time(6) not null,
         action_template_id uuid not null,
         email_template_pack_code varchar(255),
         primary key (id)

--- a/groundzero_ddl/ddl_version.sql
+++ b/groundzero_ddl/ddl_version.sql
@@ -4,5 +4,5 @@ CREATE TABLE ddl_version.version (version_tag varchar(256) PRIMARY KEY, updated_
 -- Version and patch number for the current ground zero,
 -- NOTE: These must be updated every time the repo is tagged
 -- NOTE: the CURRENT_VERSION in /patch_database.py must also be updated to match this version_tag
-INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1600, current_timestamp);
-INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.5.0', current_timestamp);
+INSERT INTO ddl_version.patches (patch_number, applied_timestamp) VALUES (1700, current_timestamp);
+INSERT INTO ddl_version.version (version_tag, updated_timestamp) VALUES ('v1.6.0', current_timestamp);

--- a/patch_database.py
+++ b/patch_database.py
@@ -8,7 +8,7 @@ from config import Config
 PATCHES_DIRECTORY = Path(__file__).parent.joinpath('patches')
 
 # CURRENT_VERSION must match the version in the ddl_version.sql file
-CURRENT_VERSION = 'v1.5.0'
+CURRENT_VERSION = 'v1.6.0'
 
 
 def get_current_patch_number(db_cursor):

--- a/patches/1700_alter_nullable_action_template.sql
+++ b/patches/1700_alter_nullable_action_template.sql
@@ -1,0 +1,12 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ALTER SCRIPT
+-- ****************************************************************************
+-- Number: 1700
+-- Purpose: To alter fields in the action template table to not be nullable
+-- Author: Daniel Banks
+-- ****************************************************************************
+
+alter table casev3.action_template_row
+    alter column cohort set not null,
+    alter column day_offset set not null,
+    alter column trigger_time set not null;

--- a/patches/rollback/1700_alter_nullable_action_template.sql
+++ b/patches/rollback/1700_alter_nullable_action_template.sql
@@ -1,0 +1,12 @@
+-- ****************************************************************************
+-- RM SQL DATABASE ROLLBACK ALTER SCRIPT
+-- ****************************************************************************
+-- Number: 1700
+-- Purpose: rollback altering fields in the action template table to not be nullable
+-- Author: Daniel Banks
+-- ****************************************************************************
+
+alter table casev3.action_template_row
+    alter column cohort drop not null,
+    alter column day_offset drop not null,
+    alter column trigger_time drop not null;

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>uk.gov.ons.ssdc</groupId>
   <artifactId>ssdc-rm-common-entity-model</artifactId>
-  <version>4.25.0-SNAPSHOT</version>
+  <version>4.25.1-SNAPSHOT</version>
 
   <parent>
     <groupId>org.springframework.boot</groupId>

--- a/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ActionTemplateRow.java
+++ b/ssdc-rm-common-entity-model/src/main/java/uk/gov/ons/ssdc/common/model/entity/ActionTemplateRow.java
@@ -28,9 +28,12 @@ public class ActionTemplateRow {
   @ManyToOne(optional = true)
   private EmailTemplate emailTemplate;
 
-  @Column private Integer cohort;
+  @Column(nullable = false)
+  private Integer cohort;
 
-  @Column private Integer dayOffset;
+  @Column(nullable = false)
+  private Integer dayOffset;
 
-  @Column private OffsetTime triggerTime;
+  @Column(nullable = false)
+  private OffsetTime triggerTime;
 }


### PR DESCRIPTION
# Has the DDL schema changed?
*Pull requests which include schema changes should be labelled with the `schema change` label for visibility*

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [x] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [x] The POM has been updated with an appropriate version bump if required

# Motivation and Context
Currently nearly all fields in action template row are nullable, this doesn't make too much sense in the eyes of self service.

# What has changed
Changed cohort, day_offset and triggertime to be not null

# How to test?
Build it locally and run against the action template support api branch https://github.com/ONSdigital/srm-support-api/pull/75

# Links
[SDCSRM-1497](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1497)

# Screenshots (if appropriate):


[SDCSRM-1497]: https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ