### PR TITLE
Upgrade to Java 21

### DIFF
--- a/.github/workflows/checks-and-tests.yml
+++ b/.github/workflows/checks-and-tests.yml
@@ -132,10 +132,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 
@@ -169,10 +169,10 @@ jobs:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
 
-      - name: Set Up JDK 17
+      - name: Set Up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 17
+          java-version: 21
           distribution: temurin
           cache: maven
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,8 @@
   <version>1.0-SNAPSHOT</version>
 
   <properties>
-    <maven.compiler.release>17</maven.compiler.release>
+    <java.version>21</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
   </properties>
 
   <dependencies>
@@ -26,7 +27,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.20</version>
+      <version>1.18.30</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -78,8 +79,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.16.0</version>
+        <version>3.24.0</version>
         <configuration>
+          <targetJdk>${java.version}</targetJdk>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
@@ -155,8 +157,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.11.0</version>
         <configuration>
-          <source>17</source>
-          <target>17</target>
+          <release>${java.version}</release>
           <encoding>UTF-8</encoding>
           <compilerArgs>
             <arg>-XDcompilePolicy=simple</arg>
@@ -171,7 +172,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.20</version>
+              <version>1.18.30</version>
             </path>
           </annotationProcessorPaths>
         </configuration>

--- a/ssdc-rm-common-entity-model/Makefile
+++ b/ssdc-rm-common-entity-model/Makefile
@@ -1,5 +1,5 @@
 format-check:
-	mvn fmt:check pmd:check
+	mvn spotless:check pmd:check
 
 build:
 	mvn compile

--- a/ssdc-rm-common-entity-model/pom.xml
+++ b/ssdc-rm-common-entity-model/pom.xml
@@ -16,8 +16,9 @@
   </parent>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <java.version>21</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
   </properties>
 
   <distributionManagement>
@@ -67,8 +68,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.16.0</version>
+        <version>3.23.0</version>
         <configuration>
+          <targetJdk>${java.version}</targetJdk>
           <excludeFromFailureFile>exclude-pmd.properties</excludeFromFailureFile>
           <failurePriority>3</failurePriority>
           <failOnViolation>true</failOnViolation>
@@ -88,15 +90,24 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Spotless (replacement for fmt-maven-plugin) -->
       <plugin>
-        <groupId>com.coveo</groupId>
-        <artifactId>fmt-maven-plugin</artifactId>
-        <version>2.8</version>
+        <groupId>com.diffplug.spotless</groupId>
+        <artifactId>spotless-maven-plugin</artifactId>
+        <version>2.43.0</version>
+        <configuration>
+          <java>
+            <googleJavaFormat>
+              <version>1.22.0</version> <!-- Java 21 compatible -->
+            </googleJavaFormat>
+          </java>
+        </configuration>
         <executions>
           <execution>
             <goals>
-              <goal>format</goal>
+              <goal>check</goal>
             </goals>
+            <phase>verify</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
# Has the DDL schema changed?
No changes to the DDL schema.

*The [common entity model pom.xml](ssdc-rm-common-entity-model/pom.xml) file `project.version` must be bumped
appropriately if there are any common entity code changes*

* [ ] This PR includes DDL schema changes and has been labelled correctly, bumping to new schema
  version: <!---Add the new schema version number if it has changes-->
* [ ] The POM has been updated with an appropriate version bump if required

# Motivation and Context
Upgrade to Java 21


# What has changed
- Update to pom files to use Java 21
- Updated pom files to set the Java version in one place then to use that wherever needed
- Using spotless-maven-plugin to replace the outdated fmt-maven-plugin
- pmd plugin upgraded to a Java 21 compatible version

These changes have been based on changes already made by the census team - see https://github.com/ONSdigital/census31-rm-ddl

# How to test?
Check that all make commands work and that you can build the common entity model.

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1570
